### PR TITLE
Allow `batch_size` instead of just `batch_shape`

### DIFF
--- a/bayesflow/distributions/diagonal_normal.py
+++ b/bayesflow/distributions/diagonal_normal.py
@@ -5,6 +5,8 @@ import math
 import numpy as np
 
 from bayesflow.types import Shape, Tensor
+from bayesflow.utils.decorators import allow_batch_size
+
 from .distribution import Distribution
 
 
@@ -73,5 +75,6 @@ class DiagonalNormal(Distribution):
 
         return result
 
+    @allow_batch_size
     def sample(self, batch_shape: Shape) -> Tensor:
         return self.mean + self.std * keras.random.normal(shape=batch_shape + (self.dim,), seed=self.seed_generator)

--- a/bayesflow/distributions/diagonal_student_t.py
+++ b/bayesflow/distributions/diagonal_student_t.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from bayesflow.types import Shape, Tensor
 from bayesflow.utils import expand_tile
+from bayesflow.utils.decorators import allow_batch_size
 
 from .distribution import Distribution
 
@@ -84,6 +85,7 @@ class DiagonalStudentT(Distribution):
 
         return result
 
+    @allow_batch_size
     def sample(self, batch_shape: Shape) -> Tensor:
         # As of writing this code, keras does not support the chi-square distribution
         # nor does it support a scale or rate parameter in Gamma. Hence, we use the relation:

--- a/bayesflow/distributions/mixture_distribution.py
+++ b/bayesflow/distributions/mixture_distribution.py
@@ -3,6 +3,8 @@ from keras import ops
 from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Shape, Tensor
+from bayesflow.utils.decorators import allow_batch_size
+
 from .distribution import Distribution
 
 
@@ -33,6 +35,7 @@ class MixtureDistribution(Distribution):
             trainable=trainable_mixture,
         )
 
+    @allow_batch_size
     def sample(self, batch_shape: Shape) -> Tensor:
         # TODO - Implement efficiently
         raise NotImplementedError

--- a/bayesflow/networks/inference_network.py
+++ b/bayesflow/networks/inference_network.py
@@ -2,6 +2,7 @@ import keras
 
 from bayesflow.types import Shape, Tensor
 from bayesflow.utils import find_distribution
+from bayesflow.utils.decorators import allow_batch_size
 
 
 class InferenceNetwork(keras.Layer):
@@ -35,6 +36,7 @@ class InferenceNetwork(keras.Layer):
     ) -> Tensor | tuple[Tensor, Tensor]:
         raise NotImplementedError
 
+    @allow_batch_size
     def sample(self, batch_shape: Shape, conditions: Tensor = None, **kwargs) -> Tensor:
         samples = self.base_distribution.sample(batch_shape)
         samples = self(samples, conditions=conditions, inverse=True, density=False, **kwargs)

--- a/bayesflow/simulators/hierarchical_simulator.py
+++ b/bayesflow/simulators/hierarchical_simulator.py
@@ -3,6 +3,7 @@ import keras
 import numpy as np
 
 from bayesflow.types import Shape
+from bayesflow.utils.decorators import allow_batch_size
 
 from .simulator import Simulator
 
@@ -11,6 +12,7 @@ class HierarchicalSimulator(Simulator):
     def __init__(self, hierarchy: Sequence[Simulator]):
         self.hierarchy = hierarchy
 
+    @allow_batch_size
     def sample(self, batch_shape: Shape, **kwargs) -> dict[str, np.ndarray]:
         input_data = {}
         output_data = {}

--- a/bayesflow/simulators/lambda_simulator.py
+++ b/bayesflow/simulators/lambda_simulator.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from bayesflow.utils import batched_call, filter_kwargs, tree_stack
+from bayesflow.utils.decorators import allow_batch_size
 
 from .simulator import Simulator
 from ..types import Shape
@@ -13,6 +14,7 @@ class LambdaSimulator(Simulator):
         self.sample_fn = sample_fn
         self.is_batched = is_batched
 
+    @allow_batch_size
     def sample(self, batch_shape: Shape, **kwargs) -> dict[str, np.ndarray]:
         # try to use only valid keyword-arguments
         kwargs = filter_kwargs(kwargs, self.sample_fn)

--- a/bayesflow/simulators/model_comparison_simulator.py
+++ b/bayesflow/simulators/model_comparison_simulator.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from bayesflow.types import Shape
 from bayesflow.utils import tree_stack
+from bayesflow.utils.decorators import allow_batch_size
 
 from bayesflow.utils import numpy_utils as npu
 
@@ -40,6 +41,7 @@ class ModelComparisonSimulator(Simulator):
         self.logits = logits
         self.use_mixed_batches = use_mixed_batches
 
+    @allow_batch_size
     def sample(self, batch_shape: Shape, **kwargs) -> dict[str, np.ndarray]:
         if not self.use_mixed_batches:
             # draw one model index for the whole batch (faster)

--- a/bayesflow/simulators/sequential_simulator.py
+++ b/bayesflow/simulators/sequential_simulator.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 import numpy as np
 
 from bayesflow.types import Shape
+from bayesflow.utils.decorators import allow_batch_size
 
 from .simulator import Simulator
 
@@ -13,6 +14,7 @@ class SequentialSimulator(Simulator):
         self.simulators = simulators
         self.expand_outputs = expand_outputs
 
+    @allow_batch_size
     def sample(self, batch_shape: Shape, **kwargs) -> dict[str, np.ndarray]:
         data = {}
         for simulator in self.simulators:

--- a/bayesflow/simulators/simulator.py
+++ b/bayesflow/simulators/simulator.py
@@ -3,12 +3,15 @@ import numpy as np
 
 from bayesflow.types import Shape
 from bayesflow.utils import tree_concatenate
+from bayesflow.utils.decorators import allow_batch_size
 
 
 class Simulator:
+    @allow_batch_size
     def sample(self, batch_shape: Shape, **kwargs) -> dict[str, np.ndarray]:
         raise NotImplementedError
 
+    @allow_batch_size
     def rejection_sample(
         self,
         batch_shape: Shape,

--- a/bayesflow/utils/decorators.py
+++ b/bayesflow/utils/decorators.py
@@ -1,0 +1,112 @@
+from collections.abc import Callable, Sequence
+from functools import wraps
+import inspect
+from typing import overload, TypeVar
+
+Fn = TypeVar("Fn", bound=Callable[..., any])
+
+# this can be done better, but not compactly in Python < 3.12
+Decorator = Fn
+
+
+def allow_args(fn: Decorator) -> Decorator:
+    """Decorator to allow another decorator to be called with or without arguments."""
+
+    @overload
+    def wrapper(f: Fn) -> Fn: ...
+    @overload
+    def wrapper(*fargs: any, **fkwargs: any) -> Fn: ...
+    def wrapper(*fargs: any, **fkwargs: any) -> Fn:
+        if len(fargs) == 1 and not fkwargs and callable(fargs[0]):
+            # called without arguments
+            return fn(fargs[0])
+        else:
+            # called with arguments, bind
+            return lambda f: fn(f, *fargs, **fkwargs)
+
+    return wrapper
+
+
+def alias(*aliases: str) -> Decorator:
+    """Decorator to create aliases for keyword arguments"""
+    aliases = list(set(aliases))
+
+    def alias_wrapper(fn: Fn) -> Fn:
+        nonlocal aliases
+
+        signature = inspect.signature(fn)
+        parameter_names = list(signature.parameters.keys())
+        candidates = [name for name in aliases if name in parameter_names]
+
+        if not candidates:
+            raise ValueError("Found no valid argument candidates in the alias list.")
+        if len(candidates) > 1:
+            raise ValueError(f"Found multiple valid argument candidates in the alias list: {candidates!r}")
+
+        argname = candidates[0]
+        argpos = parameter_names.index(argname)
+
+        aliases.remove(argname)
+
+        del signature
+        del parameter_names
+        del candidates
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            # check if multiple aliases are specified
+            matches = [name for name in kwargs if name in aliases]
+
+            if not matches:
+                return fn(*args, **kwargs)
+
+            if len(matches) > 1 or (len(matches) > 0 and len(args) > argpos):
+                raise TypeError(
+                    f"{fn.__name__}() got multiple values for argument {argname!r}.\n"
+                    f"This argument is also aliased as {aliases!r}"
+                )
+
+            # map aliases to base name
+            kwargs[argname] = kwargs.pop(matches[0])
+
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return alias_wrapper
+
+
+def argument_callback(argname: str, callback: Callable[[any], any]) -> Decorator:
+    """Decorator to apply a callback to an argument before passing it to the function"""
+
+    def callback_wrapper(fn: Fn) -> Fn:
+        argpos = list(inspect.signature(fn).parameters.keys()).index(argname)
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            if argname in kwargs:
+                kwargs[argname] = callback(kwargs[argname])
+            elif len(args) > argpos:
+                args = list(args)
+                args[argpos] = callback(args[argpos])
+
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return callback_wrapper
+
+
+def allow_batch_size(fn: Callable):
+    """Decorator to allow an integer batch_size argument in addition to a tuple batch_shape argument"""
+
+    def callback(x):
+        if isinstance(x, Sequence):
+            return x
+
+        return (x,)
+
+    fn = argument_callback("batch_shape", callback)(fn)
+    fn = alias("batch_shape", "batch_size")(fn)
+
+    return fn


### PR DESCRIPTION
This PR does two things. For any user-facing function that takes a `batch_shape` argument, we

1. Create a new argument `batch_size` that is aliased to `batch_shape`
2. Convert any non-sequences passed to one of these aliases to a one-item tuple

This ensures that integers can be used in place of tuples.

Closes #221 