### PR TITLE
Add Docs to Adapter Transforms

### DIFF
--- a/bayesflow/adapters/transforms/as_set.py
+++ b/bayesflow/adapters/transforms/as_set.py
@@ -8,6 +8,13 @@ class AsSet(ElementwiseTransform):
     The `.as_set(["x", "y"])` transform indicates that both `x` and `y` are treated as sets. 
     That is, their values will be treated as *exchangable* such that they will imply the same inference regardless of the values' order. 
     This would be useful in a linear regression context where we can index the observations in arbitrary order and always get the same regression line.
+
+    Useage: 
+    
+    adapter = (
+        bf.Adapter()
+        .as_set(["x", "y"])
+        )
     """
 
     def forward(self, data: np.ndarray, **kwargs) -> np.ndarray:

--- a/bayesflow/adapters/transforms/as_set.py
+++ b/bayesflow/adapters/transforms/as_set.py
@@ -4,6 +4,12 @@ from .elementwise_transform import ElementwiseTransform
 
 
 class AsSet(ElementwiseTransform):
+    """
+    The `.as_set(["x", "y"])` transform indicates that both `x` and `y` are treated as sets. 
+    That is, their values will be treated as *exchangable* such that they will imply the same inference regardless of the values' order. 
+    This would be useful in a linear regression context where we can index the observations in arbitrary order and always get the same regression line.
+    """
+
     def forward(self, data: np.ndarray, **kwargs) -> np.ndarray:
         return np.atleast_3d(data)
 

--- a/bayesflow/adapters/transforms/as_set.py
+++ b/bayesflow/adapters/transforms/as_set.py
@@ -5,12 +5,14 @@ from .elementwise_transform import ElementwiseTransform
 
 class AsSet(ElementwiseTransform):
     """
-    The `.as_set(["x", "y"])` transform indicates that both `x` and `y` are treated as sets. 
-    That is, their values will be treated as *exchangable* such that they will imply the same inference regardless of the values' order. 
-    This would be useful in a linear regression context where we can index the observations in arbitrary order and always get the same regression line.
+    The `.as_set(["x", "y"])` transform indicates that both `x` and `y` are treated as sets.
+    That is, their values will be treated as *exchangable* such that they will imply
+    the same inference regardless of the values' order.
+    This is useful, for example, in a linear regression context where we can index
+    the observations in arbitrary order and always get the same regression line.
 
-    Useage: 
-    
+    Useage:
+
     adapter = (
         bf.Adapter()
         .as_set(["x", "y"])

--- a/bayesflow/adapters/transforms/concatenate.py
+++ b/bayesflow/adapters/transforms/concatenate.py
@@ -13,11 +13,11 @@ from .transform import Transform
 @serializable(package="bayesflow.adapters")
 class Concatenate(Transform):
     """Concatenate multiple arrays into a new key.
-    Parameters: 
+    Parameters:
 
-    keys: 
+    keys:
 
-    into: 
+    into:
 
     """
 

--- a/bayesflow/adapters/transforms/concatenate.py
+++ b/bayesflow/adapters/transforms/concatenate.py
@@ -12,7 +12,14 @@ from .transform import Transform
 
 @serializable(package="bayesflow.adapters")
 class Concatenate(Transform):
-    """Concatenate multiple arrays into a new key."""
+    """Concatenate multiple arrays into a new key.
+    Parameters: 
+
+    keys: 
+
+    into: 
+
+    """
 
     def __init__(self, keys: Sequence[str], *, into: str, axis: int = -1):
         self.keys = keys

--- a/bayesflow/adapters/transforms/constrain.py
+++ b/bayesflow/adapters/transforms/constrain.py
@@ -16,33 +16,35 @@ from .elementwise_transform import ElementwiseTransform
 @serializable(package="bayesflow.adapters")
 class Constrain(ElementwiseTransform):
     """
-    Constrains neural network predictions of a data variable to specificied bounds. 
-    
-    Parameters: 
-        String containing the name of the data variable to be transformed e.g. "sigma". See examples below. 
+    Constrains neural network predictions of a data variable to specificied bounds.
 
-    Named Parameters: 
+    Parameters:
+        String containing the name of the data variable to be transformed e.g. "sigma". See examples below.
+
+    Named Parameters:
         lower: Lower bound for named data variable.
         upper: Upper bound for named data variable.
-        method: Method by which to shrink the network predictions space to specified bounds. Choose from 
+        method: Method by which to shrink the network predictions space to specified bounds. Choose from
             - Double bounded methods: sigmoid, expit, (default = sigmoid)
             - Lower bound only methods: softplus, exp, (default = softplus)
             - Upper bound only methods: softplus, exp, (default = softplus)
-        
 
 
-    Examples: 
-        Let sigma be the standard deviation of a normal distribution, then sigma should always be greater than zero. 
 
-        Useage: 
+    Examples:
+        Let sigma be the standard deviation of a normal distribution,
+        then sigma should always be greater than zero.
+
+        Useage:
         adapter = (
             bf.Adapter()
             .constrain("sigma", lower=0)
             )
 
-        Suppose p is the parameter for a binomial distribution where p must be in [0,1] then we would constrain the neural network to estimate p in the following way
+        Suppose p is the parameter for a binomial distribution where p must be in [0,1]
+        then we would constrain the neural network to estimate p in the following way.
 
-        Usage: 
+        Usage:
         adapter = (
             bf.Adapter()
             .constrain("p", lower=0, upper=1, method = "sigmoid")

--- a/bayesflow/adapters/transforms/constrain.py
+++ b/bayesflow/adapters/transforms/constrain.py
@@ -15,6 +15,40 @@ from .elementwise_transform import ElementwiseTransform
 
 @serializable(package="bayesflow.adapters")
 class Constrain(ElementwiseTransform):
+    """
+    Constrains neural network predictions of a data variable to specificied bounds. 
+    
+    Parameters: 
+        String containing the name of the data variable to be transformed e.g. "sigma". See examples below. 
+
+    Named Parameters: 
+        lower: Lower bound for named data variable.
+        upper: Upper bound for named data variable.
+        method: Method by which to shrink the network predictions space to specified bounds. Choose from 
+            - Double bounded methods: sigmoid, expit, (default = sigmoid)
+            - Lower bound only methods: softplus, exp, (default = softplus)
+            - Upper bound only methods: softplus, exp, (default = softplus)
+        
+
+
+    Examples: 
+        Let sigma be the standard deviation of a normal distribution, then sigma should always be greater than zero. 
+
+        Useage: 
+        adapter = (
+            bf.Adapter()
+            .constrain("sigma", lower=0)
+            )
+
+        Suppose p is the parameter for a binomial distribution where p must be in [0,1] then we would constrain the neural network to estimate p in the following way
+
+        Usage: 
+        adapter = (
+            bf.Adapter()
+            .constrain("p", lower=0, upper=1, method = "sigmoid")
+            )
+    """
+
     def __init__(
         self, *, lower: int | float | np.ndarray = None, upper: int | float | np.ndarray = None, method: str = "default"
     ):

--- a/bayesflow/adapters/transforms/convert_dtype.py
+++ b/bayesflow/adapters/transforms/convert_dtype.py
@@ -10,6 +10,9 @@ from .elementwise_transform import ElementwiseTransform
 
 @serializable(package="bayesflow.adapters")
 class ConvertDType(ElementwiseTransform):
+    """
+    Default transform used to convert all floats from float64 to float32 to be in line with keras framework. 
+    """
     def __init__(self, from_dtype: str, to_dtype: str):
         super().__init__()
 

--- a/bayesflow/adapters/transforms/convert_dtype.py
+++ b/bayesflow/adapters/transforms/convert_dtype.py
@@ -11,8 +11,9 @@ from .elementwise_transform import ElementwiseTransform
 @serializable(package="bayesflow.adapters")
 class ConvertDType(ElementwiseTransform):
     """
-    Default transform used to convert all floats from float64 to float32 to be in line with keras framework. 
+    Default transform used to convert all floats from float64 to float32 to be in line with keras framework.
     """
+
     def __init__(self, from_dtype: str, to_dtype: str):
         super().__init__()
 

--- a/bayesflow/adapters/transforms/keep.py
+++ b/bayesflow/adapters/transforms/keep.py
@@ -11,14 +11,15 @@ from .transform import Transform
 
 @serializable(package="bayesflow.adapters")
 class Keep(Transform):
-    '''
+    """
     Name the data parameters that should be kept for futher calculation. 
 
     Parameters: 
 
         cls: tuple containing the names of kept data variables as strings. 
 
-    Example: 
+    Example 1: 
+
         Two moons simulator generates data for priors alpha, r and theta as well as observation data x.
         We are interested only in theta and x, to keep only theta and x we should use the following; 
 
@@ -30,8 +31,20 @@ class Keep(Transform):
 
             )
 
+    Example 2: 
 
-    '''
+    >>> a = [1,2,3,4]
+    >>> b = [[1,2],[3,4]]
+    >>> c = [[5,6,7,8]]
+    >>> dat = dict(a=a,b=b,c =c)
+    # Here we want to only keep elements b and c 
+    >>> keeper = bf.adapters.transforms.Keep(("b","c"))
+    >>> keeper.forward(dat)
+    {'b': [[1, 2], [3, 4]], 'c': [[5, 6, 7, 8]]}
+
+
+
+    """
     def __init__(self, keys: Sequence[str]):
         self.keys = keys
 

--- a/bayesflow/adapters/transforms/keep.py
+++ b/bayesflow/adapters/transforms/keep.py
@@ -11,6 +11,27 @@ from .transform import Transform
 
 @serializable(package="bayesflow.adapters")
 class Keep(Transform):
+    '''
+    Name the data parameters that should be kept for futher calculation. 
+
+    Parameters: 
+
+        cls: tuple containing the names of kept data variables as strings. 
+
+    Example: 
+        Two moons simulator generates data for priors alpha, r and theta as well as observation data x.
+        We are interested only in theta and x, to keep only theta and x we should use the following; 
+
+        adapter = (
+            bf.adapters.Adapter()
+
+            # drop data from unneeded priors alpha, and r 
+            .keep(("theta", "x"))
+
+            )
+
+
+    '''
     def __init__(self, keys: Sequence[str]):
         self.keys = keys
 

--- a/bayesflow/adapters/transforms/keep.py
+++ b/bayesflow/adapters/transforms/keep.py
@@ -12,35 +12,35 @@ from .transform import Transform
 @serializable(package="bayesflow.adapters")
 class Keep(Transform):
     """
-    Name the data parameters that should be kept for futher calculation. 
+    Name the data parameters that should be kept for futher calculation.
 
-    Parameters: 
+    Parameters:
 
-        cls: tuple containing the names of kept data variables as strings. 
+        cls: tuple containing the names of kept data variables as strings.
 
-    Useage: 
+    Useage:
 
         Two moons simulator generates data for priors alpha, r and theta as well as observation data x.
-        We are interested only in theta and x, to keep only theta and x we should use the following; 
+        We are interested only in theta and x, to keep only theta and x we should use the following;
 
         adapter = (
             bf.adapters.Adapter()
-
-            # drop data from unneeded priors alpha, and r 
+            # only keep theta and x
             .keep(("theta", "x"))
             )
 
-    Example: 
-    >>> a = [1,2,3,4]
-    >>> b = [[1,2],[3,4]]
-    >>> c = [[5,6,7,8]]
-    >>> dat = dict(a=a,b=b,c =c)
-    # Here we want to only keep elements b and c 
-    >>> keeper = bf.adapters.transforms.Keep(("b","c"))
+    Example:
+    >>> a = [1, 2, 3, 4]
+    >>> b = [[1, 2], [3, 4]]
+    >>> c = [[5, 6, 7, 8]]
+    >>> dat = dict(a=a, b=b, c=c)
+    # Here we want to only keep elements b and c
+    >>> keeper = bf.adapters.transforms.Keep(("b", "c"))
     >>> keeper.forward(dat)
     {'b': [[1, 2], [3, 4]], 'c': [[5, 6, 7, 8]]}
 
     """
+
     def __init__(self, keys: Sequence[str]):
         self.keys = keys
 

--- a/bayesflow/adapters/transforms/keep.py
+++ b/bayesflow/adapters/transforms/keep.py
@@ -18,7 +18,7 @@ class Keep(Transform):
 
         cls: tuple containing the names of kept data variables as strings. 
 
-    Example 1: 
+    Useage: 
 
         Two moons simulator generates data for priors alpha, r and theta as well as observation data x.
         We are interested only in theta and x, to keep only theta and x we should use the following; 
@@ -28,11 +28,9 @@ class Keep(Transform):
 
             # drop data from unneeded priors alpha, and r 
             .keep(("theta", "x"))
-
             )
 
-    Example 2: 
-
+    Example: 
     >>> a = [1,2,3,4]
     >>> b = [[1,2],[3,4]]
     >>> c = [[5,6,7,8]]
@@ -41,8 +39,6 @@ class Keep(Transform):
     >>> keeper = bf.adapters.transforms.Keep(("b","c"))
     >>> keeper.forward(dat)
     {'b': [[1, 2], [3, 4]], 'c': [[5, 6, 7, 8]]}
-
-
 
     """
     def __init__(self, keys: Sequence[str]):

--- a/bayesflow/adapters/transforms/to_array.py
+++ b/bayesflow/adapters/transforms/to_array.py
@@ -13,19 +13,18 @@ from .elementwise_transform import ElementwiseTransform
 class ToArray(ElementwiseTransform):
     """
     Checks provided data for any non-arrays and converts them to numpy arrays.
-    This ensures all data is in a format suitable for training. 
+    This ensures all data is in a format suitable for training.
 
-    Example: 
+    Example:
     >>> ta = bf.adapters.transforms.ToArray()
-    >>> a = [1,2,3,4]
+    >>> a = [1, 2, 3, 4]
     >>> ta.forward(a)
         array([1, 2, 3, 4])
-    >>> b = [[1,2],[3,4]]
+    >>> b = [[1, 2], [3, 4]]
     >>> ta.forward(b)
         array([[1, 2],
             [3, 4]])
     """
-
 
     def __init__(self):
         super().__init__()

--- a/bayesflow/adapters/transforms/to_array.py
+++ b/bayesflow/adapters/transforms/to_array.py
@@ -11,6 +11,22 @@ from .elementwise_transform import ElementwiseTransform
 
 @serializable(package="bayesflow.adapters")
 class ToArray(ElementwiseTransform):
+    """
+    Checks provided data for any non-arrays and converts them to numpy arrays.
+    This ensures all data is in a format suitable for training. 
+
+    Example: 
+    >>> ta = bf.adapters.transforms.ToArray()
+    >>> a = [1,2,3,4]
+    >>> ta.forward(a)
+        array([1, 2, 3, 4])
+    >>> b = [[1,2],[3,4]]
+    >>> ta.forward(b)
+        array([[1, 2],
+            [3, 4]])
+    """
+
+
     def __init__(self):
         super().__init__()
         self.original_type = None


### PR DESCRIPTION
Added documentation for the following transforms: 
- keep 
- to_array
- convert dtype
- ad_set: gave an explaination but no useage/example as I am unsure what exactly this transform is doing
- constrain: there are many method strings that all map to the same function so I only included the first/second argument 
