### PR TITLE
Fix: coupling flows and CMs not working on GPU due to int type

### DIFF
--- a/bayesflow/networks/consistency_models/consistency_model.py
+++ b/bayesflow/networks/consistency_models/consistency_model.py
@@ -83,7 +83,7 @@ class ConsistencyModel(InferenceNetwork):
         self.s0 = float(s0)
         self.s1 = float(s1)
         # create variable that works with JIT compilation
-        self.current_step = self.add_weight(name="current_step", initializer="zeros", trainable=False, dtype="int32")
+        self.current_step = self.add_weight(name="current_step", initializer="zeros", trainable=False, dtype="int")
         self.current_step.assign(0)
 
         self.seed_generator = keras.random.SeedGenerator()
@@ -258,7 +258,7 @@ class ConsistencyModel(InferenceNetwork):
             self.current_step.assign(ops.minimum(self.current_step, self.total_steps - 1))
 
         discretization_index = ops.take(
-            self.discretization_map, ops.cast(self._schedule_discretization(self.current_step), "int32")
+            self.discretization_map, ops.cast(self._schedule_discretization(self.current_step), "int")
         )
         discretized_time = ops.take(self.discretized_times, discretization_index, axis=0)
 

--- a/bayesflow/networks/coupling_flow/permutations/random.py
+++ b/bayesflow/networks/coupling_flow/permutations/random.py
@@ -16,12 +16,12 @@ class RandomPermutation(FixedPermutation):
             shape=(xz_shape[-1],),
             initializer=keras.initializers.Constant(forward_indices),
             trainable=False,
-            dtype="int32",
+            dtype="int",
         )
 
         self.inverse_indices = self.add_weight(
             shape=(xz_shape[-1],),
             initializer=keras.initializers.Constant(inverse_indices),
             trainable=False,
-            dtype="int32",
+            dtype="int",
         )

--- a/bayesflow/networks/coupling_flow/permutations/swap.py
+++ b/bayesflow/networks/coupling_flow/permutations/swap.py
@@ -16,12 +16,12 @@ class Swap(FixedPermutation):
             shape=(xz_shape[-1],),
             initializer=keras.initializers.Constant(forward_indices),
             trainable=False,
-            dtype="int32",
+            dtype="int",
         )
 
         self.inverse_indices = self.add_variable(
             shape=(xz_shape[-1],),
             initializer=keras.initializers.Constant(inverse_indices),
             trainable=False,
-            dtype="int32",
+            dtype="int",
         )


### PR DESCRIPTION
Apparently, int32 variables are not transferred to the GPU, leading to problems with XLA. Changing the type declarations to int seems to fix the problem. It occurred at two places:

- Permutations for the coupling flows.
- Tracking the training steps for discrete-time consistency models.

Fixes #272.