### PR TITLE
Made Adapters Sliceable 

### DIFF
--- a/bayesflow/adapters/adapter.py
+++ b/bayesflow/adapters/adapter.py
@@ -78,6 +78,27 @@ class Adapter:
     def __repr__(self):
         return f"Adapter([{' -> '.join(map(repr, self.transforms))}])"
 
+    def __getitem__(self, index):
+        if isinstance(index, slice): 
+            sliced_transforms = self.transforms[index]
+            print("Are the sliced transforms a sequence")
+            print(isinstance(sliced_transforms, Sequence))
+            print("Is there an associate print method?")
+            print(sliced_transforms)
+            
+            new_adapter = Adapter(transforms = sliced_transforms)
+            return new_adapter
+        elif isinstance(index, int): 
+            if index < 0:
+                index = index + len(self.transforms) # negative indexing 
+            if index < 0 or index >= len(self.transforms): 
+                raise IndexError("Adapter index out of range.")
+            sliced_transforms = self.transforms[index]
+            new_adapter = Adapter(transforms = sliced_transforms)
+            return new_adapter
+        else:
+            raise TypeError("Invalid index type. Must be int or slice.")
+    
     def add_transform(self, transform: Transform):
         self.transforms.append(transform)
         return self
@@ -104,6 +125,7 @@ class Adapter:
         self.transforms.append(transform)
         return self
 
+    # Begin of transformed derived from transform classes 
     def as_set(self, keys: str | Sequence[str]):
         if isinstance(keys, str):
             keys = [keys]

--- a/bayesflow/adapters/adapter.py
+++ b/bayesflow/adapters/adapter.py
@@ -112,28 +112,43 @@ class Adapter:
         
     
     def __setitem__(self, index, new_value): 
+
+        if not isinstance(new_value, Adapter): 
+            raise TypeError("new_value must be an Adapter instance")
         
+        
+        new_transform = new_value.transforms 
+        
+        if len(new_transform) == 0: 
+            raise ValueError("new_value is an Adapter instance without any specified transforms, new_value Adapter must contain at least one transform.")
+
+
         if isinstance(index, slice): 
             if index.start > index.stop: 
                 raise IndexError("Index slice must be positive integers such that a < b for adapter[a:b]")
+            
             if index.stop < len(self.transforms):
-                new_transform = new_value.transforms 
-                # print("what is self.transforms[index]?")
-                # print(self.transforms[index])
-                # print("what is the value of the newvalue")
-                # print(new_transform)
-                # print(type(new_transform))
                 self.transforms[index] = new_transform
-                # else raise theory 
+            
             else: 
                 raise IndexError("Index slice out of range")
             
+
         elif isinstance(index, int): 
-            return 
-            # check if in range 
-            # if not inrange but it is just the len of the transforms (append )
-            # 
-            # else raise error 
+            if index < 0: # negative indexing 
+                index = index + len(self.transforms)
+                
+            if index < 0 or index >= len(self.transforms): 
+                raise IndexError("Index out of range.")
+                # could add that if the index is out of range, like index == len 
+                # then we just add the transform 
+            print("what is self.transforms[index]?")
+            print(self.transforms[index])
+            print("what is the value of the newvalue")
+            print(new_transform)
+            print(type(new_transform))
+        
+            self.transforms[index] = new_transform
         else: 
             raise  TypeError("Invalid index type. Must be int or slice.")
     

--- a/bayesflow/adapters/adapter.py
+++ b/bayesflow/adapters/adapter.py
@@ -15,6 +15,7 @@ from .transforms import (
     ConvertDType,
     Drop,
     ExpandDims,
+    ElementwiseTransform, # why wasn't this added before? 
     FilterTransform,
     Keep,
     LambdaTransform,
@@ -79,15 +80,25 @@ class Adapter:
         return f"Adapter([{' -> '.join(map(repr, self.transforms))}])"
 
     def __getitem__(self, index):
+
         if isinstance(index, slice): 
-            sliced_transforms = self.transforms[index]
-            print("Are the sliced transforms a sequence")
-            print(isinstance(sliced_transforms, Sequence))
-            print("Is there an associate print method?")
-            print(sliced_transforms)
-            
-            new_adapter = Adapter(transforms = sliced_transforms)
-            return new_adapter
+            if index.start > index.stop: 
+                raise IndexError("Index slice must be positive integers such that a < b for adapter[a:b]")
+            if index.stop < len(self.transforms): 
+                # print("What is the slice?")
+                # print(index)
+                # print(type(index))
+                # check that the slice is in range 
+                sliced_transforms = self.transforms[index]
+                # print("Are the sliced transforms a sequence")
+                # print(isinstance(sliced_transforms, Sequence))
+                # print("What is in the slice?")
+                # print(sliced_transforms)
+                new_adapter = Adapter(transforms = sliced_transforms)
+                return new_adapter
+            else: 
+                raise IndexError("Index slice out of range")
+                        
         elif isinstance(index, int): 
             if index < 0:
                 index = index + len(self.transforms) # negative indexing 
@@ -98,6 +109,33 @@ class Adapter:
             return new_adapter
         else:
             raise TypeError("Invalid index type. Must be int or slice.")
+        
+    
+    def __setitem__(self, index, new_value): 
+        
+        if isinstance(index, slice): 
+            if index.start > index.stop: 
+                raise IndexError("Index slice must be positive integers such that a < b for adapter[a:b]")
+            if index.stop < len(self.transforms):
+                new_transform = new_value.transforms 
+                # print("what is self.transforms[index]?")
+                # print(self.transforms[index])
+                # print("what is the value of the newvalue")
+                # print(new_transform)
+                # print(type(new_transform))
+                self.transforms[index] = new_transform
+                # else raise theory 
+            else: 
+                raise IndexError("Index slice out of range")
+            
+        elif isinstance(index, int): 
+            return 
+            # check if in range 
+            # if not inrange but it is just the len of the transforms (append )
+            # 
+            # else raise error 
+        else: 
+            raise  TypeError("Invalid index type. Must be int or slice.")
     
     def add_transform(self, transform: Transform):
         self.transforms.append(transform)


### PR DESCRIPTION
I made the adapters sliceable but one concern I have is that when I ask for `generic_adapter[0:2]` this will return an entirely new adapter instance. Depending on the use case this one matter but could cause problems. I also made a test file but it's not tracked by github, please let me know if I should also upload that. 

I also noticed that ElementwiseTransform wasn't being imported so added that as well. 
Resolves #274 