### PR TITLE
fix: FM, base_distribution.sample has no argument 'seed'

### DIFF
--- a/bayesflow/networks/flow_matching/flow_matching.py
+++ b/bayesflow/networks/flow_matching/flow_matching.py
@@ -191,9 +191,10 @@ class FlowMatching(InferenceNetwork):
         else:
             # not pre-configured, resample
             x1 = x
-            if not self.base_distribution.built:
-                # ensure that base distribution is built
-                self.base_distribution.build(keras.ops.shape(x1))
+            if not self.built:
+                xz_shape = keras.ops.shape(x1)
+                conditions_shape = None if conditions is None else keras.ops.shape(conditions)
+                self.build(xz_shape, conditions_shape)
             x0 = self.base_distribution.sample(keras.ops.shape(x1)[:-1])
 
             if self.use_optimal_transport:

--- a/bayesflow/networks/flow_matching/flow_matching.py
+++ b/bayesflow/networks/flow_matching/flow_matching.py
@@ -191,7 +191,10 @@ class FlowMatching(InferenceNetwork):
         else:
             # not pre-configured, resample
             x1 = x
-            x0 = self.base_distribution.sample(keras.ops.shape(x1), seed=self.seed_generator)
+            if not self.base_distribution.built:
+                # ensure that base distribution is built
+                self.base_distribution.build(keras.ops.shape(x1))
+            x0 = self.base_distribution.sample(keras.ops.shape(x1)[:-1])
 
             if self.use_optimal_transport:
                 x1, x0, conditions = optimal_transport(


### PR DESCRIPTION
The recent change to use the base distribution instead of a normal distribution in FlowMatching introduced an error, see #302 for an example. This PR fixes this by removing the `seed` kwarg and ensuring that `self.base_distribution` is built.