### PR TITLE
Automatic Serialization

### DIFF
--- a/bayesflow/adapters/transforms/as_set.py
+++ b/bayesflow/adapters/transforms/as_set.py
@@ -33,10 +33,3 @@ class AsSet(ElementwiseTransform):
             return np.squeeze(data, axis=2)
 
         return data
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "AsSet":
-        return cls()
-
-    def get_config(self) -> dict:
-        return {}

--- a/bayesflow/adapters/transforms/as_time_series.py
+++ b/bayesflow/adapters/transforms/as_time_series.py
@@ -30,10 +30,3 @@ class AsTimeSeries(ElementwiseTransform):
             return np.squeeze(data, axis=2)
 
         return data
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "AsTimeSeries":
-        return cls()
-
-    def get_config(self) -> dict:
-        return {}

--- a/bayesflow/adapters/transforms/concatenate.py
+++ b/bayesflow/adapters/transforms/concatenate.py
@@ -1,27 +1,21 @@
 from collections.abc import Sequence
 
 import numpy as np
-from keras.saving import (
-    deserialize_keras_object as deserialize,
-    register_keras_serializable as serializable,
-    serialize_keras_object as serialize,
-)
 
 from .transform import Transform
 
 
-@serializable(package="bayesflow.adapters")
 class Concatenate(Transform):
     """Concatenate multiple arrays into a new key. Used to specify how data variables should be treated by the network.
 
     Parameters:
         keys: Input a list of strings, where the strings are the names of data variables.
         into: A string telling the network how to use the variables named in keys.
-        axis: integer specifing along which axis to concatonate the keys. The last axis is used by default.
+        axis: integer specifying along which axis to concatenate the keys. The last axis is used by default.
 
     Example:
     Suppose you have a simulator that generates variables "beta" and "sigma" from priors and then observation
-    variables "x" and "y". We can then use concatonate in the following way
+    variables "x" and "y". We can then use concatenate in the following way
 
     adapter = (
         bf.Adapter()
@@ -30,29 +24,15 @@ class Concatenate(Transform):
      )
     """
 
-    def __init__(self, keys: Sequence[str], *, into: str, axis: int = -1, _indices: list | None = None):
+    def __init__(self, keys: Sequence[str], *, into: str, axis: int = -1, indices: list | None = None):
+        super().__init__()
+        self.initialize_config()
+
         self.keys = keys
         self.into = into
         self.axis = axis
 
-        self.indices = _indices
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "Concatenate":
-        return cls(
-            keys=deserialize(config["keys"], custom_objects),
-            into=deserialize(config["into"], custom_objects),
-            axis=deserialize(config["axis"], custom_objects),
-            _indices=deserialize(config["indices"], custom_objects),
-        )
-
-    def get_config(self) -> dict:
-        return {
-            "keys": serialize(self.keys),
-            "into": serialize(self.into),
-            "axis": serialize(self.axis),
-            "indices": serialize(self.indices),
-        }
+        self.indices = indices
 
     def forward(self, data: dict[str, any], *, strict: bool = True, **kwargs) -> dict[str, any]:
         if not strict and self.indices is None:

--- a/bayesflow/adapters/transforms/constrain.py
+++ b/bayesflow/adapters/transforms/constrain.py
@@ -1,6 +1,3 @@
-from keras.saving import (
-    register_keras_serializable as serializable,
-)
 import numpy as np
 
 from bayesflow.utils.numpy_utils import (
@@ -13,10 +10,9 @@ from bayesflow.utils.numpy_utils import (
 from .elementwise_transform import ElementwiseTransform
 
 
-@serializable(package="bayesflow.adapters")
 class Constrain(ElementwiseTransform):
     """
-    Constrains neural network predictions of a data variable to specificied bounds.
+    Constrains neural network predictions of a data variable to specified bounds.
 
     Parameters:
         String containing the name of the data variable to be transformed e.g. "sigma". See examples below.
@@ -35,7 +31,7 @@ class Constrain(ElementwiseTransform):
         1) Let sigma be the standard deviation of a normal distribution,
         then sigma should always be greater than zero.
 
-        Useage:
+        Usage:
         adapter = (
             bf.Adapter()
             .constrain("sigma", lower=0)
@@ -55,6 +51,7 @@ class Constrain(ElementwiseTransform):
         self, *, lower: int | float | np.ndarray = None, upper: int | float | np.ndarray = None, method: str = "default"
     ):
         super().__init__()
+        self.initialize_config()
 
         if lower is None and upper is None:
             raise ValueError("At least one of 'lower' or 'upper' must be provided.")
@@ -126,17 +123,6 @@ class Constrain(ElementwiseTransform):
 
         self.constrain = constrain
         self.unconstrain = unconstrain
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "Constrain":
-        return cls(**config)
-
-    def get_config(self) -> dict:
-        return {
-            "lower": self.lower,
-            "upper": self.upper,
-            "method": self.method,
-        }
 
     def forward(self, data: np.ndarray, **kwargs) -> np.ndarray:
         # forward means data space -> network space, so unconstrain the data

--- a/bayesflow/adapters/transforms/convert_dtype.py
+++ b/bayesflow/adapters/transforms/convert_dtype.py
@@ -1,14 +1,8 @@
-from keras.saving import (
-    deserialize_keras_object as deserialize,
-    register_keras_serializable as serializable,
-    serialize_keras_object as serialize,
-)
 import numpy as np
 
 from .elementwise_transform import ElementwiseTransform
 
 
-@serializable(package="bayesflow.adapters")
 class ConvertDType(ElementwiseTransform):
     """
     Default transform used to convert all floats from float64 to float32 to be in line with keras framework.
@@ -16,22 +10,10 @@ class ConvertDType(ElementwiseTransform):
 
     def __init__(self, from_dtype: str, to_dtype: str):
         super().__init__()
+        self.initialize_config()
 
         self.from_dtype = from_dtype
         self.to_dtype = to_dtype
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "ConvertDType":
-        return cls(
-            from_dtype=deserialize(config["from_dtype"], custom_objects),
-            to_dtype=deserialize(config["to_dtype"], custom_objects),
-        )
-
-    def get_config(self) -> dict:
-        return {
-            "from_dtype": serialize(self.from_dtype),
-            "to_dtype": serialize(self.to_dtype),
-        }
 
     def forward(self, data: np.ndarray, **kwargs) -> np.ndarray:
         return data.astype(self.to_dtype)

--- a/bayesflow/adapters/transforms/drop.py
+++ b/bayesflow/adapters/transforms/drop.py
@@ -1,15 +1,8 @@
 from collections.abc import Sequence
 
-from keras.saving import (
-    deserialize_keras_object as deserialize,
-    register_keras_serializable as serializable,
-    serialize_keras_object as serialize,
-)
-
 from .transform import Transform
 
 
-@serializable(package="bayesflow.adapters")
 class Drop(Transform):
     """
     Transform to drop variables from further calculation.
@@ -32,14 +25,10 @@ class Drop(Transform):
     """
 
     def __init__(self, keys: Sequence[str]):
+        super().__init__()
+        self.initialize_config()
+
         self.keys = keys
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "Drop":
-        return cls(keys=deserialize(config["keys"], custom_objects))
-
-    def get_config(self) -> dict:
-        return {"keys": serialize(self.keys)}
 
     def forward(self, data: dict[str, any], **kwargs) -> dict[str, any]:
         # no strict version because there is no requirement for the keys to be present

--- a/bayesflow/adapters/transforms/elementwise_transform.py
+++ b/bayesflow/adapters/transforms/elementwise_transform.py
@@ -1,23 +1,19 @@
-from keras.saving import register_keras_serializable as serializable
 import numpy as np
 
+from bayesflow.utils.serialization import Serializable
 
-@serializable(package="bayesflow.adapters")
-class ElementwiseTransform:
+
+class ElementwiseTransform(Serializable):
     """Base class on which other transforms are based"""
+
+    def __init__(self):
+        self.initialize_config()
 
     def __call__(self, data: np.ndarray, inverse: bool = False, **kwargs) -> np.ndarray:
         if inverse:
             return self.inverse(data, **kwargs)
 
         return self.forward(data, **kwargs)
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "ElementwiseTransform":
-        raise NotImplementedError
-
-    def get_config(self) -> dict:
-        raise NotImplementedError
 
     def forward(self, data: np.ndarray, **kwargs) -> np.ndarray:
         raise NotImplementedError

--- a/bayesflow/adapters/transforms/expand_dims.py
+++ b/bayesflow/adapters/transforms/expand_dims.py
@@ -1,10 +1,5 @@
 import numpy as np
 
-from keras.saving import (
-    deserialize_keras_object as deserialize,
-    serialize_keras_object as serialize,
-)
-
 from collections.abc import Sequence
 from .elementwise_transform import ElementwiseTransform
 
@@ -39,22 +34,10 @@ class ExpandDims(ElementwiseTransform):
 
     def __init__(self, keys: Sequence[str], *, axis: int | tuple):
         super().__init__()
+        self.initialize_config()
 
         self.keys = keys
         self.axis = axis
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "ExpandDims":
-        return cls(
-            keys=deserialize(config["keys"], custom_objects),
-            axis=deserialize(config["axis"], custom_objects),
-        )
-
-    def get_config(self) -> dict:
-        return {
-            "keys": serialize(self.keys),
-            "axis": serialize(self.axis),
-        }
 
     # noinspection PyMethodOverriding
     def forward(self, data: dict[str, any], **kwargs) -> dict[str, np.ndarray]:

--- a/bayesflow/adapters/transforms/filter_transform.py
+++ b/bayesflow/adapters/transforms/filter_transform.py
@@ -153,38 +153,18 @@ class FilterTransform(Transform):
         return data
 
     def _should_transform(self, key: str, value: np.ndarray, inverse: bool = False) -> bool:
-        match self.predicate, self.include, self.exclude:
-            case None, None, None:
+        if self.predicate:
+            if self.exclude and key in self.exclude:
+                return False
+            if self.include and key in self.include:
                 return True
-
-            case None, None, exclude:
-                return key not in exclude
-
-            case None, include, None:
-                return key in include
-
-            case None, include, exclude:
-                return key in include and key not in exclude
-
-            case predicate, None, None:
-                return predicate(key, value, inverse=inverse)
-
-            case predicate, None, exclude:
-                if key in exclude:
-                    return False
-                return predicate(key, value, inverse=inverse)
-
-            case predicate, include, None:
-                if key in include:
-                    return True
-                return predicate(key, value, inverse=inverse)
-
-            case predicate, include, exclude:
-                if key in exclude:
-                    return False
-                if key in include:
-                    return True
-                return predicate(key, value, inverse=inverse)
+            return self.predicate(key, value, inverse=inverse)
+        else:
+            if self.include and key in self.include:
+                return True
+            if self.exclude and key in self.exclude:
+                return False
+            return not self.include and not self.exclude
 
     def _apply_transform(self, key: str, value: np.ndarray, inverse: bool = False, **kwargs) -> np.ndarray:
         if key not in self.transform_map:

--- a/bayesflow/adapters/transforms/keep.py
+++ b/bayesflow/adapters/transforms/keep.py
@@ -1,15 +1,8 @@
 from collections.abc import Sequence
 
-from keras.saving import (
-    deserialize_keras_object as deserialize,
-    register_keras_serializable as serializable,
-    serialize_keras_object as serialize,
-)
-
 from .transform import Transform
 
 
-@serializable(package="bayesflow.adapters")
 class Keep(Transform):
     """
     Name the data parameters that should be kept for futher calculation.
@@ -43,14 +36,10 @@ class Keep(Transform):
     """
 
     def __init__(self, keys: Sequence[str]):
+        super().__init__()
+        self.initialize_config()
+
         self.keys = keys
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "Keep":
-        return cls(keys=deserialize(config["keys"], custom_objects))
-
-    def get_config(self) -> dict:
-        return {"keys": serialize(self.keys)}
 
     def forward(self, data: dict[str, any], **kwargs) -> dict[str, any]:
         return {key: value for key, value in data.items() if key in self.keys}

--- a/bayesflow/adapters/transforms/lambda_transform.py
+++ b/bayesflow/adapters/transforms/lambda_transform.py
@@ -1,15 +1,10 @@
 from collections.abc import Callable
 import numpy as np
-from keras.saving import (
-    deserialize_keras_object as deserialize,
-    register_keras_serializable as serializable,
-    serialize_keras_object as serialize,
-)
+
 from .elementwise_transform import ElementwiseTransform
 from ...utils import filter_kwargs
 
 
-@serializable(package="bayesflow.adapters")
 class LambdaTransform(ElementwiseTransform):
     """
     Transforms a parameter using a pair of forward and inverse functions.
@@ -23,22 +18,10 @@ class LambdaTransform(ElementwiseTransform):
         self, *, forward: Callable[[np.ndarray, ...], np.ndarray], inverse: Callable[[np.ndarray, ...], np.ndarray]
     ):
         super().__init__()
+        self.initialize_config()
 
         self._forward = forward
         self._inverse = inverse
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "LambdaTransform":
-        return cls(
-            forward=deserialize(config["forward"], custom_objects),
-            inverse=deserialize(config["inverse"], custom_objects),
-        )
-
-    def get_config(self) -> dict:
-        return {
-            "forward": serialize(self._forward),
-            "inverse": serialize(self._inverse),
-        }
 
     def forward(self, data: np.ndarray, **kwargs) -> np.ndarray:
         # filter kwargs so that other transform args like batch_size, strict, ... are not passed through

--- a/bayesflow/adapters/transforms/map_transform.py
+++ b/bayesflow/adapters/transforms/map_transform.py
@@ -1,15 +1,9 @@
 import numpy as np
-from keras.saving import (
-    deserialize_keras_object as deserialize,
-    register_keras_serializable as serializable,
-    serialize_keras_object as serialize,
-)
 
 from .elementwise_transform import ElementwiseTransform
 from .transform import Transform
 
 
-@serializable(package="bayesflow.adapters")
 class MapTransform(Transform):
     """
     Implements a transform that applies a set of elementwise transforms
@@ -17,6 +11,9 @@ class MapTransform(Transform):
     """
 
     def __init__(self, transform_map: dict[str, ElementwiseTransform]):
+        super().__init__()
+        self.initialize_config()
+
         self.transform_map = transform_map
 
     def __repr__(self):
@@ -32,13 +29,6 @@ class MapTransform(Transform):
             return f"{transform_type.__name__}({e})"
 
         return transform_type.__name__
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "MapTransform":
-        return cls(deserialize(config["transform_map"]))
-
-    def get_config(self) -> dict:
-        return {"transform_map": serialize(self.transform_map)}
 
     def forward(self, data: dict[str, np.ndarray], *, strict: bool = True, **kwargs) -> dict[str, np.ndarray]:
         data = data.copy()

--- a/bayesflow/adapters/transforms/one_hot.py
+++ b/bayesflow/adapters/transforms/one_hot.py
@@ -1,13 +1,9 @@
 import numpy as np
-from keras.saving import (
-    register_keras_serializable as serializable,
-)
 
 from bayesflow.utils.numpy_utils import one_hot
 from .elementwise_transform import ElementwiseTransform
 
 
-@serializable(package="bayesflow.adapters")
 class OneHot(ElementwiseTransform):
     """
     Changes data to be one-hot encoded.
@@ -15,6 +11,8 @@ class OneHot(ElementwiseTransform):
 
     def __init__(self, num_classes: int):
         super().__init__()
+        self.initialize_config()
+
         self.num_classes = num_classes
 
     @classmethod

--- a/bayesflow/adapters/transforms/rename.py
+++ b/bayesflow/adapters/transforms/rename.py
@@ -1,11 +1,6 @@
-from keras.saving import (
-    register_keras_serializable as serializable,
-)
-
 from .transform import Transform
 
 
-@serializable(package="bayesflow.adapters")
 class Rename(Transform):
     """
     Transform to rename keys in data dictionary. Useful to rename variables to match those required by
@@ -27,18 +22,10 @@ class Rename(Transform):
 
     def __init__(self, from_key: str, to_key: str):
         super().__init__()
+        self.initialize_config()
+
         self.from_key = from_key
         self.to_key = to_key
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "Rename":
-        return cls(
-            from_key=config["from_key"],
-            to_key=config["to_key"],
-        )
-
-    def get_config(self) -> dict:
-        return {"from_key": self.from_key, "to_key": self.to_key}
 
     def forward(self, data: dict[str, any], *, strict: bool = True, **kwargs) -> dict[str, any]:
         data = data.copy()

--- a/bayesflow/adapters/transforms/standardize.py
+++ b/bayesflow/adapters/transforms/standardize.py
@@ -1,14 +1,8 @@
-from keras.saving import (
-    deserialize_keras_object as deserialize,
-    register_keras_serializable as serializable,
-    serialize_keras_object as serialize,
-)
 import numpy as np
 
 from .elementwise_transform import ElementwiseTransform
 
 
-@serializable(package="bayesflow.adapters")
 class Standardize(ElementwiseTransform):
     """
     Transform that when applied standardizes data using typical z-score standardization i.e. for some unstandardized
@@ -33,32 +27,12 @@ class Standardize(ElementwiseTransform):
         momentum: float | None = 0.99,
     ):
         super().__init__()
+        self.initialize_config()
 
         self.mean = mean
         self.std = std
         self.axis = axis
         self.momentum = momentum
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "Standardize":
-        # Deserialize turns tuples to lists, undo it if necessary
-        deserialized_axis = deserialize(config["axis"], custom_objects)
-        if isinstance(deserialized_axis, list):
-            deserialized_axis = tuple(deserialized_axis)
-        return cls(
-            mean=deserialize(config["mean"], custom_objects),
-            std=deserialize(config["std"], custom_objects),
-            axis=deserialized_axis,
-            momentum=deserialize(config["momentum"], custom_objects),
-        )
-
-    def get_config(self) -> dict:
-        return {
-            "mean": serialize(self.mean),
-            "std": serialize(self.std),
-            "axis": serialize(self.axis),
-            "momentum": serialize(self.momentum),
-        }
 
     def forward(self, data: np.ndarray, stage: str = "training", **kwargs) -> np.ndarray:
         if self.axis is None:

--- a/bayesflow/adapters/transforms/to_array.py
+++ b/bayesflow/adapters/transforms/to_array.py
@@ -1,22 +1,17 @@
 from numbers import Number
 
 import numpy as np
-from keras.saving import (
-    register_keras_serializable as serializable,
-)
 
-from bayesflow.utils.io import deserialize_type, serialize_type
 from .elementwise_transform import ElementwiseTransform
 
 
-@serializable(package="bayesflow.adapters")
 class ToArray(ElementwiseTransform):
     """
     Checks provided data for any non-arrays and converts them to numpy arrays.
     This ensures all data is in a format suitable for training.
 
     Example:
-    >>> ta = bf.adapters.transforms.ToArray()
+    >>> ta = ToArray()
     >>> a = [1, 2, 3, 4]
     >>> ta.forward(a)
         array([1, 2, 3, 4])
@@ -28,16 +23,9 @@ class ToArray(ElementwiseTransform):
 
     def __init__(self):
         super().__init__()
+        self.initialize_config()
+
         self.original_type = None
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "ToArray":
-        instance = cls()
-        instance.original_type = deserialize_type(config["original_type"])
-        return instance
-
-    def get_config(self) -> dict:
-        return {"original_type": serialize_type(self.original_type)}
 
     def forward(self, data: any, **kwargs) -> np.ndarray:
         if self.original_type is None:

--- a/bayesflow/adapters/transforms/transform.py
+++ b/bayesflow/adapters/transforms/transform.py
@@ -1,12 +1,15 @@
-from keras.saving import register_keras_serializable as serializable
 import numpy as np
 
+from bayesflow.utils.serialization import Serializable
 
-@serializable(package="bayesflow.adapters")
-class Transform:
+
+class Transform(Serializable):
     """
     Base class on which other transforms are based
     """
+
+    def __init__(self):
+        self.initialize_config()
 
     def __call__(self, data: dict[str, np.ndarray], *, inverse: bool = False, **kwargs) -> dict[str, np.ndarray]:
         if inverse:
@@ -18,13 +21,6 @@ class Transform:
         if e := self.extra_repr():
             return f"{self.__class__.__name__}({e})"
         return self.__class__.__name__
-
-    @classmethod
-    def from_config(cls, config: dict, custom_objects=None) -> "Transform":
-        raise NotImplementedError
-
-    def get_config(self) -> dict:
-        raise NotImplementedError
 
     def forward(self, data: dict[str, np.ndarray], **kwargs) -> dict[str, np.ndarray]:
         raise NotImplementedError

--- a/bayesflow/networks/cif/cif.py
+++ b/bayesflow/networks/cif/cif.py
@@ -1,5 +1,4 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Shape, Tensor
 
@@ -9,7 +8,6 @@ from ..coupling_flow import CouplingFlow
 from .conditional_gaussian import ConditionalGaussian
 
 
-@serializable(package="bayesflow.networks")
 class CIF(InferenceNetwork):
     """Implements a continuously indexed flow (CIF) with a `CouplingFlow`
     bijection and `ConditionalGaussian` distributions p and q. Improves on
@@ -38,6 +36,8 @@ class CIF(InferenceNetwork):
         """
 
         super().__init__(base_distribution="normal", **kwargs)
+        self.initialize_config()
+
         self.bijection = CouplingFlow()
         self.p_dist = ConditionalGaussian(depth=pq_depth, width=pq_width, activation=pq_activation)
         self.q_dist = ConditionalGaussian(depth=pq_depth, width=pq_width, activation=pq_activation)

--- a/bayesflow/networks/cif/conditional_gaussian.py
+++ b/bayesflow/networks/cif/conditional_gaussian.py
@@ -1,14 +1,14 @@
 import keras
-from keras.saving import register_keras_serializable
 import numpy as np
-from ..mlp import MLP
 
 from bayesflow.types import Shape, Tensor
 from bayesflow.utils import keras_kwargs
+from bayesflow.utils.serialization import Serializable
+
+from ..mlp import MLP
 
 
-@register_keras_serializable(package="bayesflow.networks.cif")
-class ConditionalGaussian(keras.Layer):
+class ConditionalGaussian(Serializable, keras.Layer):
     """Implements a conditional gaussian distribution with neural networks for
     the means and standard deviations respectively. Bulit in reference to [1].
 
@@ -31,8 +31,9 @@ class ConditionalGaussian(keras.Layer):
         activation: str, optional, default: "swish"
             The MLP activation function
         """
-
         super().__init__(**keras_kwargs(kwargs))
+        self.initialize_config()
+
         self.means = MLP(depth=depth, width=width, activation=activation)
         self.stds = MLP(depth=depth, width=width, activation=activation)
         self.output_projector = keras.layers.Dense(None)

--- a/bayesflow/networks/consistency_models/consistency_model.py
+++ b/bayesflow/networks/consistency_models/consistency_model.py
@@ -1,19 +1,14 @@
 import keras
 from keras import ops
-from keras.saving import (
-    register_keras_serializable,
-)
 
 import numpy as np
 
 from bayesflow.types import Tensor
 from bayesflow.utils import find_network, keras_kwargs
 
-
 from ..inference_network import InferenceNetwork
 
 
-@register_keras_serializable(package="bayesflow.networks")
 class ConsistencyModel(InferenceNetwork):
     """Implements a Consistency Model with Consistency Training (CT) as
     described in [1-2]. The adaptations to CT described in [2] were taken
@@ -75,6 +70,7 @@ class ConsistencyModel(InferenceNetwork):
             Additional keyword arguments
         """
         super().__init__(base_distribution="normal", **keras_kwargs(kwargs))
+        self.initialize_config()
 
         self.total_steps = float(total_steps)
 
@@ -103,27 +99,6 @@ class ConsistencyModel(InferenceNetwork):
         self.current_step.assign(0)
 
         self.seed_generator = keras.random.SeedGenerator()
-
-        # serialization: store all parameters necessary to call __init__
-        self.config = {
-            "total_steps": total_steps,
-            "max_time": max_time,
-            "sigma2": sigma2,
-            "eps": eps,
-            "s0": s0,
-            "s1": s1,
-            **kwargs,
-        }
-        self.config = serialize_value_or_type(self.config, "subnet", subnet)
-
-    def get_config(self):
-        base_config = super().get_config()
-        return base_config | self.config
-
-    @classmethod
-    def from_config(cls, config):
-        config = deserialize_value_or_type(config, "subnet")
-        return cls(**config)
 
     def _schedule_discretization(self, step) -> float:
         """Schedule function for adjusting the discretization level `N` during

--- a/bayesflow/networks/consistency_models/consistency_model.py
+++ b/bayesflow/networks/consistency_models/consistency_model.py
@@ -7,7 +7,7 @@ from keras.saving import (
 import numpy as np
 
 from bayesflow.types import Tensor
-from bayesflow.utils import find_network, keras_kwargs, serialize_value_or_type, deserialize_value_or_type
+from bayesflow.utils import find_network, keras_kwargs
 
 
 from ..inference_network import InferenceNetwork

--- a/bayesflow/networks/coupling_flow/actnorm.py
+++ b/bayesflow/networks/coupling_flow/actnorm.py
@@ -32,6 +32,8 @@ class ActNorm(InvertibleLayer):
 
     def __init__(self, **kwargs):
         super().__init__(**keras_kwargs(kwargs))
+        self.initialize_config(exclude=["kwargs"])
+
         self.scale = None
         self.bias = None
 

--- a/bayesflow/networks/coupling_flow/coupling_flow.py
+++ b/bayesflow/networks/coupling_flow/coupling_flow.py
@@ -2,7 +2,7 @@ import keras
 from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
-from bayesflow.utils import find_permutation, keras_kwargs, serialize_value_or_type, deserialize_value_or_type
+from bayesflow.utils import find_permutation, keras_kwargs
 
 from .actnorm import ActNorm
 from .couplings import DualCoupling

--- a/bayesflow/networks/coupling_flow/couplings/dual_coupling.py
+++ b/bayesflow/networks/coupling_flow/couplings/dual_coupling.py
@@ -1,35 +1,20 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
-from bayesflow.utils import keras_kwargs
 from bayesflow.types import Tensor
+from bayesflow.utils import keras_kwargs
+
 from .single_coupling import SingleCoupling
 from ..invertible_layer import InvertibleLayer
 
 
-@serializable(package="networks.coupling_flow")
 class DualCoupling(InvertibleLayer):
     def __init__(self, subnet: str | type = "mlp", transform: str = "affine", **kwargs):
         super().__init__(**keras_kwargs(kwargs))
+        self.initialize_config()
+
         self.coupling1 = SingleCoupling(subnet, transform, **kwargs)
         self.coupling2 = SingleCoupling(subnet, transform, **kwargs)
         self.pivot = None
-
-        # serialization: store all parameters necessary to call __init__
-        self.config = {
-            "transform": transform,
-            **kwargs,
-        }
-        self.config = serialize_value_or_type(self.config, "subnet", subnet)
-
-    def get_config(self):
-        base_config = super().get_config()
-        return base_config | self.config
-
-    @classmethod
-    def from_config(cls, config):
-        config = deserialize_value_or_type(config, "subnet")
-        return cls(**config)
 
     # noinspection PyMethodOverriding
     def build(self, xz_shape, conditions_shape=None):

--- a/bayesflow/networks/coupling_flow/couplings/dual_coupling.py
+++ b/bayesflow/networks/coupling_flow/couplings/dual_coupling.py
@@ -1,7 +1,7 @@
 import keras
 from keras.saving import register_keras_serializable as serializable
 
-from bayesflow.utils import keras_kwargs, serialize_value_or_type, deserialize_value_or_type
+from bayesflow.utils import keras_kwargs
 from bayesflow.types import Tensor
 from .single_coupling import SingleCoupling
 from ..invertible_layer import InvertibleLayer

--- a/bayesflow/networks/coupling_flow/couplings/single_coupling.py
+++ b/bayesflow/networks/coupling_flow/couplings/single_coupling.py
@@ -2,7 +2,7 @@ import keras
 from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
-from bayesflow.utils import find_network, keras_kwargs, serialize_value_or_type, deserialize_value_or_type
+from bayesflow.utils import find_network, keras_kwargs
 from ..invertible_layer import InvertibleLayer
 from ..transforms import find_transform
 

--- a/bayesflow/networks/coupling_flow/invertible_layer.py
+++ b/bayesflow/networks/coupling_flow/invertible_layer.py
@@ -1,11 +1,13 @@
 import keras
 
 from bayesflow.utils import keras_kwargs
+from bayesflow.utils.serialization import Serializable
 
 
-class InvertibleLayer(keras.Layer):
+class InvertibleLayer(Serializable, keras.Layer):
     def __init__(self, **kwargs):
         super().__init__(**keras_kwargs(kwargs))
+        self.initialize_config(exclude=["kwargs"])
 
     def call(self, *args, **kwargs):
         # we cannot provide a default implementation for this

--- a/bayesflow/networks/coupling_flow/permutations/fixed_permutation.py
+++ b/bayesflow/networks/coupling_flow/permutations/fixed_permutation.py
@@ -1,14 +1,14 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Shape, Tensor
 from ..invertible_layer import InvertibleLayer
 
 
-@serializable(package="networks.coupling_flow")
 class FixedPermutation(InvertibleLayer):
     def __init__(self, forward_indices=None, inverse_indices=None, **kwargs):
         super().__init__(**kwargs)
+        self.initialize_config()
+
         self.forward_indices = forward_indices
         self.inverse_indices = inverse_indices
 

--- a/bayesflow/networks/coupling_flow/permutations/orthogonal.py
+++ b/bayesflow/networks/coupling_flow/permutations/orthogonal.py
@@ -1,11 +1,9 @@
 from keras import ops
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Shape, Tensor
 from ..invertible_layer import InvertibleLayer
 
 
-@serializable(package="networks.coupling_flow")
 class OrthogonalPermutation(InvertibleLayer):
     """Implements a learnable orthogonal transformation according to [1]. Can be
     used as an alternative to a fixed ``Permutation`` layer.
@@ -16,6 +14,8 @@ class OrthogonalPermutation(InvertibleLayer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.initialize_config()
+
         self.weight = None
 
     def build(self, xz_shape: Shape, **kwargs) -> None:

--- a/bayesflow/networks/coupling_flow/permutations/random.py
+++ b/bayesflow/networks/coupling_flow/permutations/random.py
@@ -1,11 +1,9 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Shape
 from .fixed_permutation import FixedPermutation
 
 
-@serializable(package="networks.coupling_flow")
 class RandomPermutation(FixedPermutation):
     # noinspection PyMethodOverriding
     def build(self, xz_shape: Shape, **kwargs) -> None:

--- a/bayesflow/networks/coupling_flow/permutations/swap.py
+++ b/bayesflow/networks/coupling_flow/permutations/swap.py
@@ -1,11 +1,9 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Shape
 from .fixed_permutation import FixedPermutation
 
 
-@serializable(package="networks.coupling_flow")
 class Swap(FixedPermutation):
     def build(self, xz_shape: Shape, **kwargs) -> None:
         shift = xz_shape[-1] // 2

--- a/bayesflow/networks/deep_set/deep_set.py
+++ b/bayesflow/networks/deep_set/deep_set.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import filter_kwargs
@@ -12,7 +11,6 @@ from .invariant_module import InvariantModule
 from ..summary_network import SummaryNetwork
 
 
-@serializable(package="bayesflow.networks")
 class DeepSet(SummaryNetwork):
     r"""Implements a deep set encoder introduced in [1]. This module performs the computation:
 
@@ -46,6 +44,7 @@ class DeepSet(SummaryNetwork):
         """
 
         super().__init__(**kwargs)
+        self.initialize_config()
 
         # Stack of equivariant modules for a many-to-many learnable transformation
         self.equivariant_modules = []

--- a/bayesflow/networks/deep_set/deep_set.py
+++ b/bayesflow/networks/deep_set/deep_set.py
@@ -42,7 +42,6 @@ class DeepSet(SummaryNetwork):
         """
         #TODO
         """
-
         super().__init__(**kwargs)
         self.initialize_config()
 

--- a/bayesflow/networks/deep_set/equivariant_module.py
+++ b/bayesflow/networks/deep_set/equivariant_module.py
@@ -2,15 +2,15 @@ from collections.abc import Sequence
 
 import keras
 from keras import ops, layers
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils.decorators import sanitize_input_shape
+from bayesflow.utils.serialization import Serializable
+
 from .invariant_module import InvariantModule
 
 
-@serializable(package="bayesflow.networks")
-class EquivariantModule(keras.Layer):
+class EquivariantModule(Serializable, keras.Layer):
     """Implements an equivariant module performing an equivariant transform.
 
     For details and justification, see:
@@ -38,8 +38,8 @@ class EquivariantModule(keras.Layer):
         ----------
         #TODO
         """
-
         super().__init__()
+        self.initialize_config()
 
         # Invariant module to increase expressiveness by concatenating outputs to each set member
         self.invariant_module = InvariantModule(

--- a/bayesflow/networks/deep_set/invariant_module.py
+++ b/bayesflow/networks/deep_set/invariant_module.py
@@ -2,15 +2,14 @@ from collections.abc import Sequence
 
 import keras
 from keras import layers
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import find_pooling
 from bayesflow.utils.decorators import sanitize_input_shape
+from bayesflow.utils.serialization import Serializable
 
 
-@serializable(package="bayesflow.networks")
-class InvariantModule(keras.Layer):
+class InvariantModule(Serializable, keras.Layer):
     """Implements an invariant module performing a permutation-invariant transform.
 
     For details and rationale, see:
@@ -42,6 +41,7 @@ class InvariantModule(keras.Layer):
             reserved key ``pooling_kwargs``. Example: #TODO
         """
         super().__init__()
+        self.initialize_config()
 
         # Inner fully connected net for sum decomposition: inner( pooling( inner(set) ) )
         self.inner_fc = keras.Sequential()
@@ -96,7 +96,6 @@ class InvariantModule(keras.Layer):
         set_summary : tf.Tensor
             Output of shape (batch_size,..., out_dim)
         """
-
         set_summary = self.inner_fc(input_set, training=training)
         set_summary = self.pooling_layer(set_summary, training=training)
         set_summary = self.outer_fc(set_summary, training=training)

--- a/bayesflow/networks/embeddings/fourier_embedding.py
+++ b/bayesflow/networks/embeddings/fourier_embedding.py
@@ -2,13 +2,12 @@ import numpy as np
 
 import keras
 from keras import ops
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
+from bayesflow.utils.serialization import Serializable
 
 
-@serializable(package="bayesflow.networks")
-class FourierEmbedding(keras.Layer):
+class FourierEmbedding(Serializable, keras.Layer):
     """Implements a Fourier projection with normally distributed frequencies."""
 
     def __init__(
@@ -37,9 +36,12 @@ class FourierEmbedding(keras.Layer):
         include_identity : bool, optional (default - True)
             If True, adds an identity mapping component to the embedding.
         """
-
         super().__init__(**kwargs)
-        assert embed_dim % 2 == 0, f"Embedding dimension must be even, but is {embed_dim}."
+        self.initialize_config()
+
+        if embed_dim % 2 != 0:
+            raise ValueError(f"Embedding dimension must be even, but is {embed_dim}.")
+
         self.w = self.add_weight(initializer=initializer, shape=(embed_dim // 2,), trainable=trainable)
         self.scale = scale
         self.embed_dim = embed_dim

--- a/bayesflow/networks/embeddings/recurrent_embedding.py
+++ b/bayesflow/networks/embeddings/recurrent_embedding.py
@@ -1,16 +1,16 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import expand_tile
+from bayesflow.utils.serialization import Serializable
 
 
-@serializable(package="bayesflow.networks")
-class RecurrentEmbedding(keras.Layer):
+class RecurrentEmbedding(Serializable, keras.Layer):
     """Implements a recurrent network for embedding time."""
 
     def __init__(self, embed_dim: int = 8, embedding: str = "lstm"):
         super().__init__()
+        self.initialize_config()
 
         self.embed_dim = embed_dim
         self.embedding = embedding

--- a/bayesflow/networks/embeddings/time2vec.py
+++ b/bayesflow/networks/embeddings/time2vec.py
@@ -1,12 +1,11 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import expand_tile
+from bayesflow.utils.serialization import Serializable
 
 
-@serializable(package="bayesflow.networks")
-class Time2Vec(keras.Layer):
+class Time2Vec(Serializable, keras.Layer):
     """
     Implements the Time2Vec learnbale embedding from [1].
     [1] Kazemi, S. M., Goel, R., Eghbali, S., Ramanan, J., Sahota, J., Thakur, S., ... & Brubaker, M.
@@ -15,6 +14,7 @@ class Time2Vec(keras.Layer):
 
     def __init__(self, num_periodic_features: int = 8):
         super().__init__()
+        self.initialize_config()
 
         self.num_periodic_features = num_periodic_features
         self.linear_weight = self.add_weight(

--- a/bayesflow/networks/free_form_flow/free_form_flow.py
+++ b/bayesflow/networks/free_form_flow/free_form_flow.py
@@ -1,6 +1,5 @@
 import keras
 from keras import ops
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import (
@@ -10,14 +9,11 @@ from bayesflow.utils import (
     jacobian,
     jvp,
     vjp,
-    serialize_value_or_type,
-    deserialize_value_or_type,
 )
 
 from ..inference_network import InferenceNetwork
 
 
-@serializable(package="networks.free_form_flow")
 class FreeFormFlow(InferenceNetwork):
     """Implements a dimensionality-preserving Free-form Flow.
     Incorporates ideas from [1-2].
@@ -103,26 +99,6 @@ class FreeFormFlow(InferenceNetwork):
         self.beta = beta
 
         self.seed_generator = keras.random.SeedGenerator()
-
-        # serialization: store all parameters necessary to call __init__
-        self.config = {
-            "beta": beta,
-            "base_distribution": base_distribution,
-            "hutchinson_sampling": hutchinson_sampling,
-            **kwargs,
-        }
-        self.config = serialize_value_or_type(self.config, "encoder_subnet", encoder_subnet)
-        self.config = serialize_value_or_type(self.config, "decoder_subnet", decoder_subnet)
-
-    def get_config(self):
-        base_config = super().get_config()
-        return base_config | self.config
-
-    @classmethod
-    def from_config(cls, config):
-        config = deserialize_value_or_type(config, "encoder_subnet")
-        config = deserialize_value_or_type(config, "decoder_subnet")
-        return cls(**config)
 
     # noinspection PyMethodOverriding
     def build(self, xz_shape, conditions_shape=None):

--- a/bayesflow/networks/free_form_flow/free_form_flow.py
+++ b/bayesflow/networks/free_form_flow/free_form_flow.py
@@ -76,6 +76,7 @@ class FreeFormFlow(InferenceNetwork):
             Additional keyword arguments
         """
         super().__init__(base_distribution=base_distribution, **keras_kwargs(kwargs))
+        self.initialize_config()
 
         if encoder_subnet == "mlp":
             encoder_subnet_kwargs = FreeFormFlow.ENCODER_MLP_DEFAULT_CONFIG.copy()

--- a/bayesflow/networks/inference_network.py
+++ b/bayesflow/networks/inference_network.py
@@ -3,13 +3,14 @@ import keras
 from bayesflow.types import Shape, Tensor
 from bayesflow.utils import find_distribution
 from bayesflow.utils.decorators import allow_batch_size
+from bayesflow.utils.serialization import Serializable
 
 
-class InferenceNetwork(keras.Layer):
-    MLP_DEFAULT_CONFIG = {}
-
+class InferenceNetwork(Serializable, keras.Layer):
     def __init__(self, base_distribution: str = "normal", **kwargs):
         super().__init__(**kwargs)
+        self.initialize_config()
+
         self.base_distribution = find_distribution(base_distribution)
 
     def build(self, xz_shape: Shape, conditions_shape: Shape = None) -> None:

--- a/bayesflow/networks/lstnet/lstnet.py
+++ b/bayesflow/networks/lstnet/lstnet.py
@@ -1,5 +1,4 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils.decorators import sanitize_input_shape
@@ -7,7 +6,6 @@ from .skip_recurrent import SkipRecurrentNet
 from ..summary_network import SummaryNetwork
 
 
-@serializable(package="bayesflow.networks")
 class LSTNet(SummaryNetwork):
     """
     Implements a LSTNet Architecture as described in [1]
@@ -37,6 +35,7 @@ class LSTNet(SummaryNetwork):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self.initialize_config()
 
         # Convolutional backbone -> can be extended with inception-like structure
         if not isinstance(filters, (list, tuple)):

--- a/bayesflow/networks/lstnet/skip_recurrent.py
+++ b/bayesflow/networks/lstnet/skip_recurrent.py
@@ -1,13 +1,12 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import keras_kwargs, find_recurrent_net
 from bayesflow.utils.decorators import sanitize_input_shape
+from bayesflow.utils.serialization import Serializable
 
 
-@serializable(package="bayesflow.networks")
-class SkipRecurrentNet(keras.Model):
+class SkipRecurrentNet(keras.Layer, Serializable):
     """
     Implements a Skip recurrent layer as described in [1], but allowing a more flexible
     recurrent backbone and a more flexible implementation.
@@ -31,6 +30,7 @@ class SkipRecurrentNet(keras.Model):
         **kwargs,
     ):
         super().__init__(**keras_kwargs(kwargs))
+        self.initialize_config()
 
         self.skip_conv = keras.layers.Conv1D(
             filters=input_channels * skip_steps,

--- a/bayesflow/networks/mlp/hidden_block.py
+++ b/bayesflow/networks/mlp/hidden_block.py
@@ -2,13 +2,12 @@ from typing import Literal
 
 import keras
 from keras import layers
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
+from bayesflow.utils.serialization import Serializable
 
 
-@serializable(package="bayesflow.networks")
-class ConfigurableHiddenBlock(keras.layers.Layer):
+class ConfigurableHiddenBlock(Serializable, keras.Layer):
     def __init__(
         self,
         units: int = 256,
@@ -20,6 +19,7 @@ class ConfigurableHiddenBlock(keras.layers.Layer):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self.initialize_config()
 
         self.activation_fn = keras.activations.get(activation)
         self.residual = residual

--- a/bayesflow/networks/mlp/mlp.py
+++ b/bayesflow/networks/mlp/mlp.py
@@ -2,15 +2,15 @@ from collections.abc import Sequence
 from typing import Literal
 
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import keras_kwargs
+from bayesflow.utils.serialization import Serializable
+
 from .hidden_block import ConfigurableHiddenBlock
 
 
-@serializable(package="bayesflow.networks")
-class MLP(keras.Layer):
+class MLP(Serializable, keras.Layer):
     """
     Implements a simple configurable MLP with optional residual connections and dropout.
 
@@ -50,6 +50,7 @@ class MLP(keras.Layer):
             Dropout rate for the hidden layers in the internal layers.
         """
         super().__init__(**keras_kwargs(kwargs))
+        self.initialize_config()
 
         if widths is not None:
             if depth is not None or width is not None:

--- a/bayesflow/networks/summary_network.py
+++ b/bayesflow/networks/summary_network.py
@@ -4,11 +4,14 @@ from bayesflow.metrics.functional import maximum_mean_discrepancy
 from bayesflow.types import Tensor
 from bayesflow.utils import find_distribution, keras_kwargs
 from bayesflow.utils.decorators import sanitize_input_shape
+from bayesflow.utils.serialization import Serializable
 
 
-class SummaryNetwork(keras.Layer):
+class SummaryNetwork(Serializable, keras.Layer):
     def __init__(self, base_distribution: str = None, **kwargs):
         super().__init__(**keras_kwargs(kwargs))
+        self.initialize_config()
+
         self.base_distribution = find_distribution(base_distribution)
 
     @sanitize_input_shape

--- a/bayesflow/networks/transformers/fusion_transformer.py
+++ b/bayesflow/networks/transformers/fusion_transformer.py
@@ -1,6 +1,5 @@
 import keras
 from keras import layers
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import check_lengths_same
@@ -10,7 +9,6 @@ from ..summary_network import SummaryNetwork
 from .mab import MultiHeadAttentionBlock
 
 
-@serializable(package="bayesflow.networks")
 class FusionTransformer(SummaryNetwork):
     """Implements a more flexible version of the TimeSeriesTransformer that applies a series of self-attention layers
     followed by cross-attention between the representation and a learnable template summarized via a recurrent net."""
@@ -79,8 +77,8 @@ class FusionTransformer(SummaryNetwork):
         **kwargs : dict
             Additional keyword arguments passed to the base layer.
         """
-
         super().__init__(**kwargs)
+        self.initialize_config()
 
         # Ensure all tuple-settings have the same length
         check_lengths_same(embed_dims, num_heads, mlp_depths, mlp_widths)

--- a/bayesflow/networks/transformers/isab.py
+++ b/bayesflow/networks/transformers/isab.py
@@ -1,12 +1,12 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
+from bayesflow.utils.serialization import Serializable
+
 from .mab import MultiHeadAttentionBlock
 
 
-@serializable(package="bayesflow.networks")
-class InducedSetAttentionBlock(keras.Layer):
+class InducedSetAttentionBlock(Serializable, keras.Layer):
     """Implements the ISAB block from [1] which represents learnable self-attention specifically
     designed to deal with large sets via a learnable set of "inducing points".
 
@@ -38,6 +38,7 @@ class InducedSetAttentionBlock(keras.Layer):
         """
 
         super().__init__(**kwargs)
+        self.initialize_config()
 
         self.num_inducing_points = num_inducing_points
         self.inducing_points = self.add_weight(

--- a/bayesflow/networks/transformers/mab.py
+++ b/bayesflow/networks/transformers/mab.py
@@ -1,13 +1,12 @@
 import keras
 from keras import layers
-from keras.saving import register_keras_serializable as serializable
 
-from bayesflow.types import Tensor
 from bayesflow.networks import MLP
+from bayesflow.types import Tensor
+from bayesflow.utils.serialization import Serializable
 
 
-@serializable(package="bayesflow.networks")
-class MultiHeadAttentionBlock(keras.Layer):
+class MultiHeadAttentionBlock(Serializable, keras.Layer):
     """Implements the MAB block from [1] which represents learnable cross-attention.
 
     [1] Lee, J., Lee, Y., Kim, J., Kosiorek, A., Choi, S., & Teh, Y. W. (2019).
@@ -35,8 +34,8 @@ class MultiHeadAttentionBlock(keras.Layer):
         ----------
         ##TODO
         """
-
         super().__init__(**kwargs)
+        self.initialize_config()
 
         self.input_projector = layers.Dense(embed_dim)
         self.attention = layers.MultiHeadAttention(
@@ -87,6 +86,3 @@ class MultiHeadAttentionBlock(keras.Layer):
             out = self.ln_post(out, training=training)
 
         return out
-
-    def build(self, input_shape):
-        super().build(input_shape)

--- a/bayesflow/networks/transformers/pma.py
+++ b/bayesflow/networks/transformers/pma.py
@@ -1,14 +1,14 @@
 import keras
 import keras.ops as ops
-from keras.saving import register_keras_serializable as serializable
 
-from bayesflow.types import Tensor
 from bayesflow.networks import MLP
+from bayesflow.types import Tensor
+from bayesflow.utils.serialization import Serializable
+
 from .mab import MultiHeadAttentionBlock
 
 
-@serializable(package="bayesflow.networks")
-class PoolingByMultiHeadAttention(keras.Layer):
+class PoolingByMultiHeadAttention(Serializable, keras.Layer):
     """Implements the pooling with multi-head attention (PMA) block from [1] which represents
     a permutation-invariant encoder for set-based inputs.
 
@@ -44,8 +44,8 @@ class PoolingByMultiHeadAttention(keras.Layer):
         ----------
         ##TODO
         """
-
         super().__init__(**kwargs)
+        self.initialize_config()
 
         self.mab = MultiHeadAttentionBlock(
             embed_dim=embed_dim,

--- a/bayesflow/networks/transformers/sab.py
+++ b/bayesflow/networks/transformers/sab.py
@@ -1,10 +1,7 @@
-from keras.saving import register_keras_serializable as serializable
-
 from bayesflow.types import Tensor
 from .mab import MultiHeadAttentionBlock
 
 
-@serializable(package="bayesflow.networks")
 class SetAttentionBlock(MultiHeadAttentionBlock):
     """Implements the SAB block from [1] which represents learnable self-attention.
 

--- a/bayesflow/networks/transformers/set_transformer.py
+++ b/bayesflow/networks/transformers/set_transformer.py
@@ -1,5 +1,4 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import check_lengths_same
@@ -11,7 +10,6 @@ from .isab import InducedSetAttentionBlock
 from .pma import PoolingByMultiHeadAttention
 
 
-@serializable(package="bayesflow.networks")
 class SetTransformer(SummaryNetwork):
     """Implements the set transformer architecture from [1] which ultimately represents
     a learnable permutation-invariant function. Designed to naturally model interactions in
@@ -78,8 +76,8 @@ class SetTransformer(SummaryNetwork):
         **kwargs : dict
             Additional keyword arguments passed to the base layer.
         """
-
         super().__init__(**kwargs)
+        self.initialize_config()
 
         check_lengths_same(embed_dims, num_heads, mlp_depths, mlp_widths)
 

--- a/bayesflow/networks/transformers/time_series_transformer.py
+++ b/bayesflow/networks/transformers/time_series_transformer.py
@@ -1,5 +1,4 @@
 import keras
-from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import check_lengths_same
@@ -10,7 +9,6 @@ from ..summary_network import SummaryNetwork
 from .mab import MultiHeadAttentionBlock
 
 
-@serializable(package="bayesflow.networks")
 class TimeSeriesTransformer(SummaryNetwork):
     def __init__(
         self,
@@ -66,8 +64,8 @@ class TimeSeriesTransformer(SummaryNetwork):
         **kwargs : dict
             Additional keyword arguments passed to the base layer.
         """
-
         super().__init__(**kwargs)
+        self.initialize_config()
 
         # Ensure all tuple-settings have the same length
         check_lengths_same(embed_dims, num_heads, mlp_depths, mlp_widths)

--- a/bayesflow/utils/__init__.py
+++ b/bayesflow/utils/__init__.py
@@ -8,6 +8,7 @@ from .devices import devices
 from .dict_utils import (
     convert_args,
     convert_kwargs,
+    filter_keys,
     filter_kwargs,
     keras_kwargs,
     split_tensors,
@@ -45,7 +46,7 @@ from .plot_utils import (
     make_quadratic,
     add_metric,
 )
-from .serialization import serialize_value_or_type, deserialize_value_or_type
+from .serialization import deserialize, serialize
 from .tensor_utils import (
     concatenate,
     expand,

--- a/bayesflow/utils/dict_utils.py
+++ b/bayesflow/utils/dict_utils.py
@@ -32,7 +32,7 @@ def convert_args(f: Callable, *args: any, **kwargs: any) -> tuple[any, ...]:
 
 
 def convert_kwargs(f: Callable, *args: any, **kwargs: any) -> dict[str, any]:
-    """Convert positional and keyword arguments qto just keyword arguments for f"""
+    """Convert positional and keyword arguments to just keyword arguments for f"""
     if not args:
         return kwargs
 
@@ -47,6 +47,51 @@ def convert_kwargs(f: Callable, *args: any, **kwargs: any) -> dict[str, any]:
         parameters[name] = value
 
     return parameters
+
+
+def filter_keys(mapping: dict, *, include: list = None, exclude: list = None, strict: bool = True) -> dict:
+    """
+    Filter keys of a dictionary based on inclusion or exclusion lists.
+
+    Parameters
+    ----------
+    mapping : dict
+        The dictionary to filter.
+    include : list, optional
+        List of keys to include in the filtered dictionary. If None, no keys are included based on this list.
+    exclude : list, optional
+        List of keys to exclude from the filtered dictionary. If None, no keys are excluded based on this list.
+    strict : bool, default=True
+        If True, raises an error if any keys in the include or exclude lists are not found in the dictionary.
+
+    Returns
+    -------
+    dict
+        The filtered dictionary.
+
+    Raises
+    ------
+    KeyError
+        If `strict` is True and any keys in the include or exclude lists are not found in the dictionary.
+    """
+    if strict:
+        if include:
+            missing_keys = set(include) - set(mapping.keys())
+            if missing_keys:
+                raise KeyError(f"Could not find keys from include list in source mapping: {list(missing_keys)!r}")
+
+        if exclude:
+            missing_keys = set(exclude) - set(mapping.keys())
+            if missing_keys:
+                raise KeyError(f"Could not find keys from exclude list in source mapping: {list(missing_keys)!r}")
+
+    if include is not None:
+        mapping = {key: value for key, value in mapping.items() if key in include}
+
+    if exclude is not None:
+        mapping = {key: value for key, value in mapping.items() if key not in exclude}
+
+    return mapping
 
 
 def filter_kwargs(kwargs: Mapping[str, T], f: Callable) -> Mapping[str, T]:

--- a/bayesflow/utils/inspect_utils.py
+++ b/bayesflow/utils/inspect_utils.py
@@ -1,0 +1,20 @@
+import inspect
+
+
+def get_calling_frame_info(*, robust: bool = True):
+    if not robust:
+        return inspect.getouterframes(inspect.currentframe())[3]
+
+    # could be in a special environment, loop through the whole stack
+    stack = inspect.stack()
+
+    idx = None
+    for i, frame_info in enumerate(stack):
+        if frame_info.filename == __file__ and frame_info.function == "get_calling_frame_info":
+            idx = i + 2
+            break
+
+    if idx is None or idx >= len(stack):
+        raise RuntimeError("Could not find calling frame.")
+
+    return stack[idx]

--- a/bayesflow/utils/serialization.py
+++ b/bayesflow/utils/serialization.py
@@ -1,78 +1,111 @@
+from collections.abc import Collection
+from copy import copy
+
+import inspect
 import keras
 
-
-PREFIX = "_bayesflow_"
-
-
-def serialize_value_or_type(config, name, obj):
-    """Serialize an object that can be either a value or a type
-    and add it to a copy of the supplied dictionary.
-
-    Parameters
-    ----------
-    config  : dict
-        Dictionary to add the serialized object to. This function does not
-        modify the dictionary in place, but returns a modified copy.
-    name    : str
-        Name of the obj that should be stored. Required for later deserialization.
-    obj     : object or type
-        The object to serialize. If `obj` is of type `type`, we use
-        `keras.saving.get_registered_name` to obtain the registered type name.
-        If it is not a type, we try to serialize it as a Keras object.
-
-    Returns
-    -------
-    updated_config  : dict
-        Updated dictionary with a new key `"_bayesflow_<name>_type"` or
-        `"_bayesflow_<name>_val"`. The prefix is used to avoid name collisions,
-        the suffix indicates how the stored value has to be deserialized.
-
-    Notes
-    -----
-    We allow strings or `type` parameters at several places to instantiate objects
-    of a given type (e.g., `subnet` in `CouplingFlow`). As `type` objects cannot
-    be serialized, we have to distinguish the two cases for serialization and
-    deserialization. This function is a helper function to standardize and
-    simplify this.
-    """
-    updated_config = config.copy()
-    if isinstance(obj, type):
-        updated_config[f"{PREFIX}{name}_type"] = keras.saving.get_registered_name(obj)
-    else:
-        updated_config[f"{PREFIX}{name}_val"] = keras.saving.serialize_keras_object(obj)
-    return updated_config
+from bayesflow.utils import filter_keys
+from bayesflow.utils.inspect_utils import get_calling_frame_info
 
 
-def deserialize_value_or_type(config, name):
-    """Deserialize an object that can be either a value or a type and add
-    it to the supplied dictionary.
+def deserialize(obj, custom_objects=None, module_objects=None):
+    if inspect.isclass(obj):
+        return keras.saving.get_registered_object(obj, custom_objects=custom_objects, module_objects=module_objects)
+    return keras.saving.deserialize_keras_object(obj, custom_objects=custom_objects, module_objects=module_objects)
 
-    Parameters
-    ----------
-    config  : dict
-        Dictionary containing the object to deserialize. If a type was
-        serialized, it should contain the key `"_bayesflow_<name>_type"`.
-        If an object was serialized, it should contain the key
-        `"_bayesflow_<name>_val"`. In a copy of this dictionary,
-        the item will be replaced with the key `name`.
-    name    : str
-        Name of the object to deserialize.
 
-    Returns
-    -------
-    updated_config  : dict
-        Updated dictionary with a new key `name`, with a value that is either
-        a type or an object.
+class Serializable:
+    def __init_subclass__(cls, **kwargs):
+        # get the calling module's name, e.g. "bayesflow.networks.inference_network"
+        stack = inspect.stack()
+        module = inspect.getmodule(stack[1][0])
+        package = copy(module.__name__)
 
-    See Also
-    --------
-    serialize_value_or_type
-    """
-    updated_config = config.copy()
-    if f"{PREFIX}{name}_type" in config:
-        updated_config[name] = keras.saving.get_registered_object(config[f"{PREFIX}{name}_type"])
-        del updated_config[f"{PREFIX}{name}_type"]
-    elif f"{PREFIX}{name}_val" in config:
-        updated_config[name] = keras.saving.deserialize_keras_object(config[f"{PREFIX}{name}_val"])
-        del updated_config[f"{PREFIX}{name}_val"]
-    return updated_config
+        name = copy(cls.__name__)
+
+        # register subclasses as keras serializable
+        keras.saving.register_keras_serializable(package=package, name=name)(cls)
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        kwargs = config.get("constructor_arguments", {})
+        kwargs = {key: deserialize(value, custom_objects) for key, value in kwargs.items()}
+
+        instance = cls(**kwargs)
+
+        stateful_fields = config.get("stateful_fields", {})
+        for field_name, field_value in stateful_fields.items():
+            setattr(instance, field_name, deserialize(field_value, custom_objects))
+
+        # TODO: what do we do with the keras config values? e.g. "name", "trainable", etc.
+
+        return instance
+
+    def get_config(self):
+        base_config = super().get_config() if hasattr(super(), "get_config") else {}
+
+        config = getattr(self, "config", {})
+
+        config["stateful_fields"] = {key: serialize(getattr(self, key)) for key in config.get("stateful_fields", [])}
+
+        return base_config | config
+
+    def initialize_config(self, *, include: list[str] = None, exclude: list[str] = None, stateful: list[str] = None):
+        """
+        Initialize the configuration dictionary for a Serializable subclass by looking up constructor arguments and
+        remembering stateful fields to be serialized later.
+
+        Call this method after calling super().__init__() in the constructor of a subclass of Serializable.
+
+        Parameters
+        ----------
+        include : list[str], optional
+            List of keys to include in the configuration. If None, no keys are included based on this list.
+        exclude : list[str], optional
+            List of keys to exclude from the configuration. If None, no keys are excluded based on this list.
+        stateful : list[str], optional
+            List of stateful fields to include in the configuration. If None, no stateful fields are included.
+
+        Returns
+        -------
+        dict
+            The configuration dictionary containing constructor arguments and stateful fields.
+
+        Raises
+        ------
+        RuntimeError
+            If this method is called from a non-constructor context.
+        """
+        if stateful is None:
+            stateful = []
+
+        # ensure that the frame above the current one is a constructor
+        frame_info = get_calling_frame_info()
+
+        # check that the calling function is an __init__()
+        if frame_info.function != "__init__":
+            raise RuntimeError("Cannot automatically initialize config from non-constructor context.")
+
+        # get argument info from the calling frame
+        arginfo = inspect.getargvalues(frame_info.frame)
+
+        # drop self from locals and turn args into key-value dictionary
+        args = {key: arginfo.locals[key] for key in arginfo.args[1:]}
+
+        args = filter_keys(args, include=include, exclude=exclude, strict=True)
+
+        self.config = {
+            "constructor_arguments": serialize(args),
+            "stateful_fields": list(stateful),
+        }
+
+        return self.config
+
+
+def serialize(obj):
+    if not isinstance(obj, str) and isinstance(obj, Collection):
+        return keras.tree.map_structure(serialize, obj)
+
+    if inspect.isclass(obj):
+        return keras.saving.get_registered_name(obj)
+    return keras.saving.serialize_keras_object(obj)

--- a/tests/test_adapters/conftest.py
+++ b/tests/test_adapters/conftest.py
@@ -19,7 +19,7 @@ def custom_objects():
 def adapter():
     from bayesflow.adapters import Adapter
 
-    d = (
+    adapter = (
         Adapter()
         .to_array()
         .as_set(["s1", "s2"])
@@ -40,7 +40,7 @@ def adapter():
         .rename("o1", "o2")
     )
 
-    return d
+    return adapter
 
 
 @pytest.fixture()


### PR DESCRIPTION
The goals of this PR are:

- [x] Remove the need to implement `from_config` and `get_config` methods for most objects
- [x] Remove the need to save a `config` object in the constructor of most objects
- [x] Unify the serialization of types, functions, and other objects
- [ ] Improve the serialization of functions, especially with respect to numpy

To achieve the above goals, this PR introduces:

- A custom `serialize` and `deserialize` function that wrap around the `keras` utilities
- A custom `Serializable` class that automatically implements `from_config` and `get_config`

Fixes #342 