### PR TITLE
Feature: allow use of Keras functional API by sanitizing build input shapes

### DIFF
--- a/bayesflow/networks/deep_set/deep_set.py
+++ b/bayesflow/networks/deep_set/deep_set.py
@@ -5,6 +5,7 @@ from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import filter_kwargs
+from bayesflow.utils.decorators import sanitize_input_shape
 
 from .equivariant_module import EquivariantModule
 from .invariant_module import InvariantModule
@@ -78,6 +79,7 @@ class DeepSet(SummaryNetwork):
         self.output_projector = keras.layers.Dense(summary_dim, activation="linear")
         self.summary_dim = summary_dim
 
+    @sanitize_input_shape
     def build(self, input_shape):
         super().build(input_shape)
         self.call(keras.ops.zeros(input_shape))

--- a/bayesflow/networks/deep_set/equivariant_module.py
+++ b/bayesflow/networks/deep_set/equivariant_module.py
@@ -5,6 +5,7 @@ from keras import ops, layers
 from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
+from bayesflow.utils.decorators import sanitize_input_shape
 from .invariant_module import InvariantModule
 
 
@@ -66,6 +67,7 @@ class EquivariantModule(keras.Layer):
 
         self.layer_norm = layers.LayerNormalization() if layer_norm else None
 
+    @sanitize_input_shape
     def build(self, input_shape):
         self.call(keras.ops.zeros(input_shape))
 

--- a/bayesflow/networks/deep_set/invariant_module.py
+++ b/bayesflow/networks/deep_set/invariant_module.py
@@ -6,6 +6,7 @@ from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import find_pooling
+from bayesflow.utils.decorators import sanitize_input_shape
 
 
 @serializable(package="bayesflow.networks")
@@ -76,6 +77,7 @@ class InvariantModule(keras.Layer):
 
         self.pooling_layer = find_pooling(pooling, **pooling_kwargs)
 
+    @sanitize_input_shape
     def build(self, input_shape):
         self.call(keras.ops.zeros(input_shape))
 

--- a/bayesflow/networks/lstnet/lstnet.py
+++ b/bayesflow/networks/lstnet/lstnet.py
@@ -2,6 +2,7 @@ import keras
 from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
+from bayesflow.utils.decorators import sanitize_input_shape
 from .skip_recurrent import SkipRecurrentNet
 from ..summary_network import SummaryNetwork
 
@@ -78,6 +79,7 @@ class LSTNet(SummaryNetwork):
         x = self.output_projector(x)
         return x
 
+    @sanitize_input_shape
     def build(self, input_shape):
         super().build(input_shape)
         self.call(keras.ops.zeros(input_shape))

--- a/bayesflow/networks/lstnet/skip_recurrent.py
+++ b/bayesflow/networks/lstnet/skip_recurrent.py
@@ -3,6 +3,7 @@ from keras.saving import register_keras_serializable as serializable
 
 from bayesflow.types import Tensor
 from bayesflow.utils import keras_kwargs, find_recurrent_net
+from bayesflow.utils.decorators import sanitize_input_shape
 
 
 @serializable(package="bayesflow.networks")
@@ -58,5 +59,6 @@ class SkipRecurrentNet(keras.Model):
         skip_summary = self.skip_recurrent(self.skip_conv(time_series), training=training)
         return keras.ops.concatenate((direct_summary, skip_summary), axis=-1)
 
+    @sanitize_input_shape
     def build(self, input_shape):
         self.call(keras.ops.zeros(input_shape))

--- a/bayesflow/networks/summary_network.py
+++ b/bayesflow/networks/summary_network.py
@@ -3,6 +3,7 @@ import keras
 from bayesflow.metrics.functional import maximum_mean_discrepancy
 from bayesflow.types import Tensor
 from bayesflow.utils import find_distribution, keras_kwargs
+from bayesflow.utils.decorators import sanitize_input_shape
 
 
 class SummaryNetwork(keras.Layer):
@@ -10,6 +11,7 @@ class SummaryNetwork(keras.Layer):
         super().__init__(**keras_kwargs(kwargs))
         self.base_distribution = find_distribution(base_distribution)
 
+    @sanitize_input_shape
     def build(self, input_shape):
         if self.base_distribution is not None:
             output_shape = keras.ops.shape(self.call(keras.ops.zeros(input_shape)))


### PR DESCRIPTION
Fixes #329.

This PR adds a decorator `sanitize_input_shape` to replace the first entry of input_shape with a dummy batch size of 32 in case it is None.
The decorator is added to the relevant network build functions.

If you have any ideas/wishes regarding naming, please let me know and I'll adjust it.