### PR TITLE
fix issue #328

### DIFF
--- a/bayesflow/approximators/continuous_approximator.py
+++ b/bayesflow/approximators/continuous_approximator.py
@@ -141,7 +141,7 @@ class ContinuousApproximator(Approximator):
     ) -> dict[str, np.ndarray]:
         conditions = self.adapter(conditions, strict=False, stage="inference", **kwargs)
         # at inference time, inference_variables are estimated by the networks and thus ignored in conditions
-        conditions = {k: v for k, v in conditions.items() if k != "inference_variables"}
+        conditions.pop("inference_variables", None)
         conditions = keras.tree.map_structure(keras.ops.convert_to_tensor, conditions)
         conditions = {"inference_variables": self._sample(num_samples=num_samples, **conditions, **kwargs)}
         conditions = keras.tree.map_structure(keras.ops.convert_to_numpy, conditions)

--- a/bayesflow/approximators/continuous_approximator.py
+++ b/bayesflow/approximators/continuous_approximator.py
@@ -140,6 +140,8 @@ class ContinuousApproximator(Approximator):
         **kwargs,
     ) -> dict[str, np.ndarray]:
         conditions = self.adapter(conditions, strict=False, stage="inference", **kwargs)
+        # at inference time, inference_variables are estimated by the networks and thus ignored in conditions
+        conditions = {k: v for k, v in conditions.items() if k != "inference_variables"}
         conditions = keras.tree.map_structure(keras.ops.convert_to_tensor, conditions)
         conditions = {"inference_variables": self._sample(num_samples=num_samples, **conditions, **kwargs)}
         conditions = keras.tree.map_structure(keras.ops.convert_to_numpy, conditions)

--- a/bayesflow/approximators/model_comparison_approximator.py
+++ b/bayesflow/approximators/model_comparison_approximator.py
@@ -208,6 +208,7 @@ class ModelComparisonApproximator(Approximator):
         **kwargs,
     ) -> np.ndarray:
         conditions = self.adapter(conditions, strict=False, stage="inference", **kwargs)
+        # at inference time, model_indices are predicted by the networks and thus ignored in conditions
         conditions.pop("model_indices", None)
         conditions = keras.tree.map_structure(keras.ops.convert_to_tensor, conditions)
 

--- a/bayesflow/approximators/model_comparison_approximator.py
+++ b/bayesflow/approximators/model_comparison_approximator.py
@@ -208,7 +208,7 @@ class ModelComparisonApproximator(Approximator):
         **kwargs,
     ) -> np.ndarray:
         conditions = self.adapter(conditions, strict=False, stage="inference", **kwargs)
-        conditions = {k: v for k, v in conditions.items() if k != "model_indices"}
+        conditions.pop("model_indices", None)
         conditions = keras.tree.map_structure(keras.ops.convert_to_tensor, conditions)
 
         output = self._predict(**conditions, **kwargs)

--- a/bayesflow/approximators/model_comparison_approximator.py
+++ b/bayesflow/approximators/model_comparison_approximator.py
@@ -208,6 +208,7 @@ class ModelComparisonApproximator(Approximator):
         **kwargs,
     ) -> np.ndarray:
         conditions = self.adapter(conditions, strict=False, stage="inference", **kwargs)
+        conditions = {k: v for k, v in conditions.items() if k != "model_indices"}
         conditions = keras.tree.map_structure(keras.ops.convert_to_tensor, conditions)
 
         output = self._predict(**conditions, **kwargs)


### PR DESCRIPTION
This PR fixes issue #328 by removing `inference_variables` from conditions in the continuous approximator before passing conditions to the networks. Taggine @Kucharssim to double check that this fixes the issue and @LarsKue for reviewing this PR. 