### PR TITLE
Fix unused weights warning in coupling flow

### DIFF
--- a/bayesflow/networks/mlp/hidden_block.py
+++ b/bayesflow/networks/mlp/hidden_block.py
@@ -51,7 +51,7 @@ class ConfigurableHiddenBlock(keras.layers.Layer):
     def build(self, input_shape):
         self.dense.build(input_shape)
 
-        if input_shape[-1] != self.units:
+        if input_shape[-1] != self.units and self.residual:
             self.projector = self.add_weight(
                 shape=(input_shape[-1], self.units), initializer="glorot_uniform", trainable=True, name="projector"
             )


### PR DESCRIPTION
The projector weights were created even when no residual connections were required, leading to warnings as their gradients were not present, as they had no influence on the loss.

Fixes #331