### PR TITLE
adapter: support log and sqrt transforms

### DIFF
--- a/bayesflow/adapters/adapter.py
+++ b/bayesflow/adapters/adapter.py
@@ -483,7 +483,7 @@ class Adapter(MutableSequence[Transform]):
         if isinstance(keys, str):
             keys = [keys]
 
-        transform = ExpandDims(keys, axis=axis)
+        transform = MapTransform({key: ExpandDims(axis=axis) for key in keys})
         self.transforms.append(transform)
         return self
 
@@ -508,14 +508,14 @@ class Adapter(MutableSequence[Transform]):
         Parameters
         ----------
         keys : str or Sequence of str
-            The names of the variables to expand.
+            The names of the variables to transform.
         p1 : boolean
             Add 1 to the input before taking the logarithm?
         """
         if isinstance(keys, str):
             keys = [keys]
 
-        transform = Log(keys, p1=p1)
+        transform = MapTransform({key: Log(p1=p1) for key in keys})
         self.transforms.append(transform)
         return self
 
@@ -555,12 +555,12 @@ class Adapter(MutableSequence[Transform]):
         Parameters
         ----------
         keys : str or Sequence of str
-            The names of the variables to expand.
+            The names of the variables to transform.
         """
         if isinstance(keys, str):
             keys = [keys]
 
-        transform = Sqrt(keys)
+        transform = MapTransform({key: Sqrt() for key in keys})
         self.transforms.append(transform)
         return self
 

--- a/bayesflow/adapters/adapter.py
+++ b/bayesflow/adapters/adapter.py
@@ -19,9 +19,11 @@ from .transforms import (
     FilterTransform,
     Keep,
     LambdaTransform,
+    Log,
     MapTransform,
     OneHot,
     Rename,
+    Sqrt,
     Standardize,
     ToArray,
     Transform,
@@ -500,6 +502,23 @@ class Adapter(MutableSequence[Transform]):
         self.transforms.append(transform)
         return self
 
+    def log(self, keys: str | Sequence[str], *, p1: bool = False):
+        """Append an :py:class:`~transforms.Log` transform to the adapter.
+
+        Parameters
+        ----------
+        keys : str or Sequence of str
+            The names of the variables to expand.
+        p1 : boolean
+            Add 1 to the input before taking the logarithm?
+        """
+        if isinstance(keys, str):
+            keys = [keys]
+
+        transform = Log(keys, p1=p1)
+        self.transforms.append(transform)
+        return self
+
     def one_hot(self, keys: str | Sequence[str], num_classes: int):
         """Append a :py:class:`~transforms.OneHot` transform to the adapter.
 
@@ -528,6 +547,21 @@ class Adapter(MutableSequence[Transform]):
             New variable name
         """
         self.transforms.append(Rename(from_key, to_key))
+        return self
+
+    def sqrt(self, keys: str | Sequence[str]):
+        """Append an :py:class:`~transforms.Sqrt` transform to the adapter.
+
+        Parameters
+        ----------
+        keys : str or Sequence of str
+            The names of the variables to expand.
+        """
+        if isinstance(keys, str):
+            keys = [keys]
+
+        transform = Sqrt(keys)
+        self.transforms.append(transform)
         return self
 
     def standardize(

--- a/bayesflow/adapters/transforms/__init__.py
+++ b/bayesflow/adapters/transforms/__init__.py
@@ -10,9 +10,11 @@ from .expand_dims import ExpandDims
 from .filter_transform import FilterTransform
 from .keep import Keep
 from .lambda_transform import LambdaTransform
+from .log import Log
 from .map_transform import MapTransform
 from .one_hot import OneHot
 from .rename import Rename
+from .sqrt import Sqrt
 from .standardize import Standardize
 from .to_array import ToArray
 from .transform import Transform

--- a/bayesflow/adapters/transforms/log.py
+++ b/bayesflow/adapters/transforms/log.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from collections.abc import Sequence
+
+from .elementwise_transform import ElementwiseTransform
+
+
+class Log(ElementwiseTransform):
+    """Log transforms a variable.
+
+    Parameters
+    ----------
+    p1 : boolean
+        Add 1 to the input before taking the logarithm?
+
+    Examples
+    --------
+    >>> adapter = bf.Adapter().log(["x"])
+    """
+
+    def __init__(self, keys: Sequence[str], *, p1: bool = False):
+        super().__init__()
+        self.keys = keys
+        self.p1 = p1
+
+    def forward(self, data: dict[str, any], **kwargs) -> dict[str, np.ndarray]:
+        if self.p1:
+            return {k: (np.log1p(v) if k in self.keys else v) for k, v in data.items()}
+        else:
+            return {k: (np.log(v) if k in self.keys else v) for k, v in data.items()}
+
+    def inverse(self, data: dict[str, any], **kwargs) -> dict[str, np.ndarray]:
+        if self.p1:
+            return {k: (np.expm1(v) if k in self.keys else v) for k, v in data.items()}
+        else:
+            return {k: (np.exp(v) if k in self.keys else v) for k, v in data.items()}
+
+    @classmethod
+    def from_config(cls, config: dict, custom_objects=None) -> "Log":
+        return cls()
+
+    def get_config(self) -> dict:
+        return {}

--- a/bayesflow/adapters/transforms/sqrt.py
+++ b/bayesflow/adapters/transforms/sqrt.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from collections.abc import Sequence
+
+from .elementwise_transform import ElementwiseTransform
+
+
+class Sqrt(ElementwiseTransform):
+    """Square-root transform a variable.
+
+    Examples
+    --------
+    >>> adapter = bf.Adapter().sqrt(["x"])
+    """
+
+    def __init__(self, keys: Sequence[str]):
+        super().__init__()
+        self.keys = keys
+
+    def forward(self, data: dict[str, any], **kwargs) -> dict[str, np.ndarray]:
+        return {k: (np.sqrt(v) if k in self.keys else v) for k, v in data.items()}
+
+    def inverse(self, data: dict[str, any], **kwargs) -> dict[str, np.ndarray]:
+        return {k: (np.square(v) if k in self.keys else v) for k, v in data.items()}
+
+    @classmethod
+    def from_config(cls, config: dict, custom_objects=None) -> "Sqrt":
+        return cls()
+
+    def get_config(self) -> dict:
+        return {}

--- a/bayesflow/adapters/transforms/sqrt.py
+++ b/bayesflow/adapters/transforms/sqrt.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-from collections.abc import Sequence
-
 from .elementwise_transform import ElementwiseTransform
 
 
@@ -13,15 +11,11 @@ class Sqrt(ElementwiseTransform):
     >>> adapter = bf.Adapter().sqrt(["x"])
     """
 
-    def __init__(self, keys: Sequence[str]):
-        super().__init__()
-        self.keys = keys
+    def forward(self, data: np.ndarray, **kwargs) -> np.ndarray:
+        return np.sqrt(data)
 
-    def forward(self, data: dict[str, any], **kwargs) -> dict[str, np.ndarray]:
-        return {k: (np.sqrt(v) if k in self.keys else v) for k, v in data.items()}
-
-    def inverse(self, data: dict[str, any], **kwargs) -> dict[str, np.ndarray]:
-        return {k: (np.square(v) if k in self.keys else v) for k, v in data.items()}
+    def inverse(self, data: np.ndarray, **kwargs) -> np.ndarray:
+        return np.square(data)
 
     @classmethod
     def from_config(cls, config: dict, custom_objects=None) -> "Sqrt":

--- a/tests/test_adapters/conftest.py
+++ b/tests/test_adapters/conftest.py
@@ -30,8 +30,7 @@ def adapter():
         .concatenate(["y1", "y2"], into="y")
         .expand_dims(["z1"], axis=2)
         .apply(forward=forward_transform, inverse=inverse_transform)
-        # TODO: fix this in keras
-        # .apply(include="p1", forward=np.log, inverse=np.exp)
+        .log("p1")
         .constrain("p2", lower=0)
         .standardize(exclude=["t1", "t2", "o1"])
         .drop("d1")

--- a/tests/test_adapters/test_adapters.py
+++ b/tests/test_adapters/test_adapters.py
@@ -88,16 +88,12 @@ def test_constrain():
     assert np.isneginf(result["x_both_disc2"][0])
     assert np.isinf(result["x_both_disc2"][-1])
 
+
 def test_log_sqrt(random_data):
     # check if constraint-implied transforms are applied correctly
     from bayesflow.adapters import Adapter
 
-    adapter = (
-        Adapter()
-        .log(["o1", "p2"])
-        .log("t1", p1=True)
-        .sqrt("p1")
-    )
+    adapter = Adapter().log(["o1", "p2"]).log("t1", p1=True).sqrt("p1")
 
     result = adapter(random_data)
 

--- a/tests/test_adapters/test_adapters.py
+++ b/tests/test_adapters/test_adapters.py
@@ -93,11 +93,20 @@ def test_simple_transforms(random_data):
     # check if simple transforms are applied correctly
     from bayesflow.adapters import Adapter
 
-    adapter = Adapter().log(["o1", "p2"]).log("t1", p1=True).sqrt("p1")
+    adapter = Adapter().log(["p2", "t2"]).log("t1", p1=True).sqrt("p1")
 
     result = adapter(random_data)
 
-    assert np.array_equal(result["o1"], np.log(random_data["o1"]))
     assert np.array_equal(result["p2"], np.log(random_data["p2"]))
+    assert np.array_equal(result["t2"], np.log(random_data["t2"]))
     assert np.array_equal(result["t1"], np.log1p(random_data["t1"]))
     assert np.array_equal(result["p1"], np.sqrt(random_data["p1"]))
+
+    # inverse results should match the original input
+    inverse = adapter.inverse(result)
+
+    assert np.array_equal(inverse["p2"], random_data["p2"])
+    assert np.array_equal(inverse["t2"], random_data["t2"])
+    assert np.array_equal(inverse["t1"], random_data["t1"])
+    # numerical inaccuries prevent np.array_equal to work here
+    assert np.allclose(inverse["p1"], random_data["p1"])

--- a/tests/test_adapters/test_adapters.py
+++ b/tests/test_adapters/test_adapters.py
@@ -87,3 +87,21 @@ def test_constrain():
     assert np.isinf(result["x_upper_disc2"][0])
     assert np.isneginf(result["x_both_disc2"][0])
     assert np.isinf(result["x_both_disc2"][-1])
+
+def test_log_sqrt(random_data):
+    # check if constraint-implied transforms are applied correctly
+    from bayesflow.adapters import Adapter
+
+    adapter = (
+        Adapter()
+        .log(["o1", "p2"])
+        .log("t1", p1=True)
+        .sqrt("p1")
+    )
+
+    result = adapter(random_data)
+
+    assert np.isfinite(result["o1"][0, 0])
+    assert np.isfinite(result["p2"][0, 0])
+    assert np.isfinite(result["t1"][0, 0])
+    assert np.isfinite(result["p1"][0, 0])

--- a/tests/test_adapters/test_adapters.py
+++ b/tests/test_adapters/test_adapters.py
@@ -89,8 +89,8 @@ def test_constrain():
     assert np.isinf(result["x_both_disc2"][-1])
 
 
-def test_log_sqrt(random_data):
-    # check if constraint-implied transforms are applied correctly
+def test_simple_transforms(random_data):
+    # check if simple transforms are applied correctly
     from bayesflow.adapters import Adapter
 
     adapter = Adapter().log(["o1", "p2"]).log("t1", p1=True).sqrt("p1")

--- a/tests/test_adapters/test_adapters.py
+++ b/tests/test_adapters/test_adapters.py
@@ -97,7 +97,7 @@ def test_simple_transforms(random_data):
 
     result = adapter(random_data)
 
-    assert np.isfinite(result["o1"][0, 0])
-    assert np.isfinite(result["p2"][0, 0])
-    assert np.isfinite(result["t1"][0, 0])
-    assert np.isfinite(result["p1"][0, 0])
+    assert np.array_equal(result["o1"], np.log(random_data["o1"]))
+    assert np.array_equal(result["p2"], np.log(random_data["p2"]))
+    assert np.array_equal(result["t1"], np.log1p(random_data["t1"]))
+    assert np.array_equal(result["p1"], np.sqrt(random_data["p1"]))


### PR DESCRIPTION
This PR adds support for log and sqrt transforms as requested by @stefanradev93.

@LarsKue I noticed that we are using two different patterns to deal with `keys` in the adapter. One that uses keys directly in the internal adapter transforms (e.g., expand_dims) and another that loops over the keys inside the main `Adapter` (e.g., `as_set`). Is this international? If so, when shall we apply which pattern?