### PR TITLE
Docs: add CNAME and .nojekyll file for new docs

### DIFF
--- a/docsrc/polyversion/static/CNAME
+++ b/docsrc/polyversion/static/CNAME
@@ -1,0 +1,1 @@
+bayesflow.org


### PR DESCRIPTION
A CNAME file is required for deployment to the correct domain, bayesflow.org. Related to #372.