### PR TITLE
Docs: make action upload hidden files as well

### DIFF
--- a/.github/workflows/multiversion-docs.yaml
+++ b/.github/workflows/multiversion-docs.yaml
@@ -55,7 +55,7 @@ jobs:
         run: |
           cd ./gh-pages-dev
           git rm --quiet -rf .
-          cp -R ../repo/docs/* ./
+          cp -r ../repo/docs/. ./
           git config --local user.email ""
           git config --local user.name "github-actions"
           git add -A


### PR DESCRIPTION
Copying the docs to the folder for upload excluded hidden files, so the `.nojekyll` file got lost. This PR fixes this.
Related to #372