### PR TITLE
Populate API Reference landing page

### DIFF
--- a/bayesflow/adapters/__init__.py
+++ b/bayesflow/adapters/__init__.py
@@ -1,5 +1,6 @@
 """
-A collection of :py:class:`~bayesflow.adapters.Adapter` transforms, which tell BayesFlow how to interpret your :py:class:`~bayesflow.simulators.Simulator` output and plug it into neural networks for training and inference.
+A collection of :py:class:`~bayesflow.adapters.Adapter` transforms, which tell BayesFlow how to interpret your
+:py:class:`~bayesflow.simulators.Simulator` output and plug it into neural networks for training and inference.
 """
 
 from . import transforms

--- a/bayesflow/adapters/__init__.py
+++ b/bayesflow/adapters/__init__.py
@@ -1,3 +1,7 @@
+"""
+A collection of :py:class:`~bayesflow.adapters.Adapter` transforms, which tell BayesFlow how to interpret your :py:class:`~bayesflow.simulators.Simulator` output and plug it into neural networks for training and inference.
+"""
+
 from . import transforms
 from .adapter import Adapter
 

--- a/bayesflow/approximators/__init__.py
+++ b/bayesflow/approximators/__init__.py
@@ -1,3 +1,7 @@
+"""
+A collection of :py:class:`~bayesflow.approximators.Approximator`\ s, which embody the inference task and the neural network components used to perform it.
+"""
+
 from .approximator import Approximator
 from .continuous_approximator import ContinuousApproximator
 from .point_approximator import PointApproximator

--- a/bayesflow/approximators/__init__.py
+++ b/bayesflow/approximators/__init__.py
@@ -1,5 +1,6 @@
 """
-A collection of :py:class:`~bayesflow.approximators.Approximator`\ s, which embody the inference task and the neural network components used to perform it.
+A collection of :py:class:`~bayesflow.approximators.Approximator`\ s, which embody the inference task and the
+neural network components used to perform it.
 """
 
 from .approximator import Approximator

--- a/bayesflow/datasets/__init__.py
+++ b/bayesflow/datasets/__init__.py
@@ -2,6 +2,7 @@
 A collection of `keras.utils.PyDataset <https://keras.io/api/utils/python_utils/#pydataset-class>`__\ s, which wrap your data-generating process (i.e., your :py:class:`~bayesflow.simulators.Simulator`).
 What type of Dataset you use determines the effective training strategy (e.g., online or offline).
 """
+
 from .offline_dataset import OfflineDataset
 from .online_dataset import OnlineDataset
 from .disk_dataset import DiskDataset

--- a/bayesflow/datasets/__init__.py
+++ b/bayesflow/datasets/__init__.py
@@ -1,7 +1,7 @@
 """
 A collection of `keras.utils.PyDataset <https://keras.io/api/utils/python_utils/#pydataset-class>`__\ s, which
-wrap your data-generating process (i.e., your :py:class:`~bayesflow.simulators.Simulator`).
-What type of Dataset you use determines the effective training strategy (e.g., online or offline).
+wrap your data-generating process (i.e., your :py:class:`~bayesflow.simulators.Simulator`) and thus determine the
+effective training strategy (e.g., online or offline).
 """
 
 from .offline_dataset import OfflineDataset

--- a/bayesflow/datasets/__init__.py
+++ b/bayesflow/datasets/__init__.py
@@ -1,3 +1,7 @@
+"""
+A collection of `keras.utils.PyDataset <https://keras.io/api/utils/python_utils/#pydataset-class>`__\ s, which wrap your data-generating process (i.e., your :py:class:`~bayesflow.simulators.Simulator`).
+What type of Dataset you use determines the effective training strategy (e.g., online or offline).
+"""
 from .offline_dataset import OfflineDataset
 from .online_dataset import OnlineDataset
 from .disk_dataset import DiskDataset

--- a/bayesflow/datasets/__init__.py
+++ b/bayesflow/datasets/__init__.py
@@ -1,5 +1,6 @@
 """
-A collection of `keras.utils.PyDataset <https://keras.io/api/utils/python_utils/#pydataset-class>`__\ s, which wrap your data-generating process (i.e., your :py:class:`~bayesflow.simulators.Simulator`).
+A collection of `keras.utils.PyDataset <https://keras.io/api/utils/python_utils/#pydataset-class>`__\ s, which
+wrap your data-generating process (i.e., your :py:class:`~bayesflow.simulators.Simulator`).
 What type of Dataset you use determines the effective training strategy (e.g., online or offline).
 """
 

--- a/bayesflow/diagnostics/__init__.py
+++ b/bayesflow/diagnostics/__init__.py
@@ -1,3 +1,6 @@
+"""
+A collection of plotting utilities and metrics for evaluating trained :py:class:`~bayesflow.workflows.Workflow`\ s.
+"""
 from .metrics import root_mean_squared_error, calibration_error, posterior_contraction
 
 from .plots import (

--- a/bayesflow/diagnostics/__init__.py
+++ b/bayesflow/diagnostics/__init__.py
@@ -1,6 +1,7 @@
 """
 A collection of plotting utilities and metrics for evaluating trained :py:class:`~bayesflow.workflows.Workflow`\ s.
 """
+
 from .metrics import root_mean_squared_error, calibration_error, posterior_contraction
 
 from .plots import (

--- a/bayesflow/distributions/__init__.py
+++ b/bayesflow/distributions/__init__.py
@@ -3,6 +3,7 @@ A collection of :py:class:`~bayesflow.distributions.Distribution`\ s,
 which represent the latent space for :py:class:`~bayesflow.networks.InferenceNetwork`\ s
 or the summary space of :py:class:`~bayesflow.networks.SummaryNetwork`\ s.
 """
+
 from .distribution import Distribution
 from .diagonal_normal import DiagonalNormal
 from .diagonal_student_t import DiagonalStudentT

--- a/bayesflow/distributions/__init__.py
+++ b/bayesflow/distributions/__init__.py
@@ -1,3 +1,8 @@
+"""
+A collection of :py:class:`~bayesflow.distributions.Distribution`\ s,
+which represent the latent space for :py:class:`~bayesflow.networks.InferenceNetwork`\ s
+or the summary space of :py:class:`~bayesflow.networks.SummaryNetwork`\ s.
+"""
 from .distribution import Distribution
 from .diagonal_normal import DiagonalNormal
 from .diagonal_student_t import DiagonalStudentT

--- a/bayesflow/experimental/__init__.py
+++ b/bayesflow/experimental/__init__.py
@@ -1,6 +1,7 @@
 """
 Unstable or largely untested networks. Proceed with caution.
 """
+
 from .cif import CIF
 from .continuous_time_consistency_model import ContinuousTimeConsistencyModel
 from .free_form_flow import FreeFormFlow

--- a/bayesflow/experimental/__init__.py
+++ b/bayesflow/experimental/__init__.py
@@ -1,3 +1,6 @@
+"""
+Unstable or largely untested networks. Proceed with caution.
+"""
 from .cif import CIF
 from .continuous_time_consistency_model import ContinuousTimeConsistencyModel
 from .free_form_flow import FreeFormFlow

--- a/bayesflow/experimental/__init__.py
+++ b/bayesflow/experimental/__init__.py
@@ -1,5 +1,5 @@
 """
-Unstable or largely untested networks. Proceed with caution.
+Unstable or largely untested networks, proceed with caution.
 """
 
 from .cif import CIF

--- a/bayesflow/metrics/__init__.py
+++ b/bayesflow/metrics/__init__.py
@@ -1,5 +1,6 @@
 """
-A collection of `keras.Metric <https://keras.io/api/metrics/base_metric/#metric-class>`__\ s for evaluating the performance of models.
+A collection of `keras.Metric <https://keras.io/api/metrics/base_metric/#metric-class>`__\ s for evaluating the
+performance of models.
 """
 
 from . import functional

--- a/bayesflow/metrics/__init__.py
+++ b/bayesflow/metrics/__init__.py
@@ -1,3 +1,7 @@
+"""
+A collection of `keras.Metric <https://keras.io/api/metrics/base_metric/#metric-class>`__\ s for evaluating the performance of models.
+"""
+
 from . import functional
 from .maximum_mean_discrepancy import MaximumMeanDiscrepancy
 from .root_mean_squard_error import RootMeanSquaredError

--- a/bayesflow/networks/__init__.py
+++ b/bayesflow/networks/__init__.py
@@ -1,6 +1,7 @@
 """
 A rich collection of neural network architectures for use in :py:class:`~bayesflow.approximators.Approximator`\ s.
 """
+
 from .consistency_models import ConsistencyModel
 from .coupling_flow import CouplingFlow
 from .deep_set import DeepSet

--- a/bayesflow/networks/__init__.py
+++ b/bayesflow/networks/__init__.py
@@ -1,3 +1,6 @@
+"""
+A rich collection of neural network architectures for use in :py:class:`~bayesflow.approximators.Approximator`\ s.
+"""
 from .consistency_models import ConsistencyModel
 from .coupling_flow import CouplingFlow
 from .deep_set import DeepSet

--- a/bayesflow/simulators/__init__.py
+++ b/bayesflow/simulators/__init__.py
@@ -3,6 +3,7 @@ This module provides the :py:class:`~bayesflow.simulators.Simulator`, which is t
 Its primary function is to sample data with the :py:meth:`~bayesflow.simulators.Simulator.sample` method.
 The module also contains several other kinds of Simulators, as well as the function :py:func:`~bayesflow.simulators.make_simulator` to facilitate easy implementation.
 """
+
 from .sequential_simulator import SequentialSimulator
 from .hierarchical_simulator import HierarchicalSimulator
 from .lambda_simulator import LambdaSimulator

--- a/bayesflow/simulators/__init__.py
+++ b/bayesflow/simulators/__init__.py
@@ -1,9 +1,7 @@
 """
-This module provides the :py:class:`~bayesflow.simulators.Simulator`, which is the base implementation of a
-generative mathematical model, or data generating process.
-Its primary function is to sample data with the :py:meth:`~bayesflow.simulators.Simulator.sample` method.
-The module also contains several other kinds of Simulators, as well as the function
-:py:func:`~bayesflow.simulators.make_simulator` to facilitate easy implementation.
+This module provides :py:class:`~bayesflow.simulators.Simulator`, :py:function:`~bayesflow.simulators.make_simulator`,
+and several other kinds of :py:class:`~bayesflow.simulators.Simulator` implementations, which serve as generative
+mathematical models, or data generating processes, with their primary function being to sample data.
 """
 
 from .sequential_simulator import SequentialSimulator

--- a/bayesflow/simulators/__init__.py
+++ b/bayesflow/simulators/__init__.py
@@ -1,3 +1,8 @@
+"""
+This module provides the :py:class:`~bayesflow.simulators.Simulator`, which is the base implementation of a generative mathematical model, data generating process.
+Its primary function is to sample data with the :py:meth:`~bayesflow.simulators.Simulator.sample` method.
+The module also contains several other kinds of Simulators, as well as the function :py:func:`~bayesflow.simulators.make_simulator` to facilitate easy implementation.
+"""
 from .sequential_simulator import SequentialSimulator
 from .hierarchical_simulator import HierarchicalSimulator
 from .lambda_simulator import LambdaSimulator

--- a/bayesflow/simulators/__init__.py
+++ b/bayesflow/simulators/__init__.py
@@ -1,7 +1,9 @@
 """
-This module provides the :py:class:`~bayesflow.simulators.Simulator`, which is the base implementation of a generative mathematical model, data generating process.
+This module provides the :py:class:`~bayesflow.simulators.Simulator`, which is the base implementation of a
+generative mathematical model, or data generating process.
 Its primary function is to sample data with the :py:meth:`~bayesflow.simulators.Simulator.sample` method.
-The module also contains several other kinds of Simulators, as well as the function :py:func:`~bayesflow.simulators.make_simulator` to facilitate easy implementation.
+The module also contains several other kinds of Simulators, as well as the function
+:py:func:`~bayesflow.simulators.make_simulator` to facilitate easy implementation.
 """
 
 from .sequential_simulator import SequentialSimulator

--- a/bayesflow/types/__init__.py
+++ b/bayesflow/types/__init__.py
@@ -1,5 +1,5 @@
 """
-Custom types.
+Custom types used for type annotations.
 
 .. currentmodule:: bayesflow.types
 

--- a/bayesflow/utils/__init__.py
+++ b/bayesflow/utils/__init__.py
@@ -1,3 +1,7 @@
+"""
+A collection of utility functions, mostly used for internal purposes.
+"""
+
 from . import (
     keras_utils,
     logging,

--- a/bayesflow/workflows/__init__.py
+++ b/bayesflow/workflows/__init__.py
@@ -1,3 +1,6 @@
+"""
+Provides :py:class:`~bayesflow.workflows.BasicWorkflow`, a high-level interface for working on typical BayesFlow applications without having to worry about the internals.
+"""
 from .basic_workflow import BasicWorkflow
 
 from ..utils._docs import _add_imports_to_all

--- a/bayesflow/workflows/__init__.py
+++ b/bayesflow/workflows/__init__.py
@@ -1,5 +1,6 @@
 """
-Provides :py:class:`~bayesflow.workflows.BasicWorkflow`, a high-level interface for working on typical BayesFlow applications without having to worry about the internals.
+Provides :py:class:`~bayesflow.workflows.BasicWorkflow`, a high-level interface for working on typical BayesFlow
+applications without having to worry about the internals.
 """
 
 from .basic_workflow import BasicWorkflow

--- a/bayesflow/workflows/__init__.py
+++ b/bayesflow/workflows/__init__.py
@@ -1,6 +1,7 @@
 """
 Provides :py:class:`~bayesflow.workflows.BasicWorkflow`, a high-level interface for working on typical BayesFlow applications without having to worry about the internals.
 """
+
 from .basic_workflow import BasicWorkflow
 
 from ..utils._docs import _add_imports_to_all


### PR DESCRIPTION
Some docstrings don't yet render correctly:

- datasets is missing the 2nd half of the text
- experimental is missing the "Proceed with caution."
- simulators is missing the 2nd half of the text

We could also try to improve the links to `keras` classes with [intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html).