### PR TITLE
Docs: clarify installation instructions for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,15 @@ More tutorials are always welcome! Please consider making a pull request if you 
 
 ## Install
 
-BayesFlow is available to install via pip:
+BayesFlow v2 is not yet installable via PyPI, but you can use the following command to install the latest version of the `main` branch:
 
 ```bash
-pip install bayesflow
+pip install git+https://github.com/bayesflow-org/bayesflow.git
 ```
+
+If you encounter problems with this or require more control, please refer to the instructions to install from source below.
+
+Note: `pip install bayesflow` will install the v1 version of BayesFlow.
 
 ### Backend
 

--- a/docsrc/source/index.md
+++ b/docsrc/source/index.md
@@ -64,9 +64,7 @@ More tutorials are always welcome! Please consider making a pull request if you 
 
     .. tab-item:: pip
 
-        .. code-block:: bash
-
-            pip install bayesflow
+        The v2 version is not available on PyPI yet, please install from source.
 
     .. tab-item:: source
 


### PR DESCRIPTION
Closes #386.

Our installation instructions feature `pip install bayesflow`, which is not in place yet for version 2. This PR adds the respective comments. This might lead to slight confusion, as in the README we basically install from source in both sections, but I think this is ok for now. If not, please make any adaptations you see fit.