### PR TITLE
Add c2st

### DIFF
--- a/bayesflow/diagnostics/metrics/classifier_two_sample_test.py
+++ b/bayesflow/diagnostics/metrics/classifier_two_sample_test.py
@@ -1,0 +1,121 @@
+from typing import Sequence, Mapping, Any
+
+import numpy as np
+
+import keras
+
+from bayesflow.utils.exceptions import ShapeError
+from bayesflow.networks import MLP
+
+
+def classifier_two_sample_test(
+    estimates: np.ndarray,
+    targets: np.ndarray,
+    metric: str = "accuracy",
+    patience: int = 10,
+    max_epochs: int = 1000,
+    batch_size: int = 64,
+    return_metric_only: bool = True,
+    validation_split: float = 0.5,
+    standardize: bool = True,
+    mlp_widths: Sequence = (256, 256),
+    **kwargs,
+) -> float | Mapping[str, Any]:
+    """
+    C2ST metric [1] between samples from two distributions computed using a neural classifier.
+    Can be computationally expensive, since it involves training of a neural classifier.
+
+    Note: works best for large numbers of samples and averaged across different posteriors.
+
+    Code adapted from https://github.com/sbi-benchmark/sbibm/blob/main/sbibm/metrics/c2st.py
+
+    [1] Lopez-Paz, D., & Oquab, M. (2016). Revisiting classifier two-sample tests. arXiv:1610.06545.
+
+    Parameters
+    ----------
+    estimates : np.ndarray
+        Array of shape (num_samples_est, num_variables) containing samples representing estimated quantities
+        (e.g., approximate posterior samples).
+    targets : np.ndarray
+        Array of shape (num_samples_tar, num_variables) containing target samples
+        (e.g., samples from a reference posterior).
+    metric : str, optional
+        Metric to evaluate the classifier performance. Default is "accuracy".
+    patience : int, optional
+        Number of epochs with no improvement after which training will be stopped. Default is 5.
+    max_epochs : int, optional
+        Maximum number of epochs to train the classifier. Default is 1000.
+    batch_size : int, optional
+        Number of samples per batch during training. Default is 64.
+    return_metric_only : bool, optional
+        If True, only the final validation metric is returned. Otherwise, a dictionary with the score, classifier, and
+        full training history is returned. Default is True.
+    validation_split : float, optional
+        Fraction of the training data to be used as validation data. Default is 0.5.
+    standardize : bool, optional
+        If True, both estimates and targets will be standardized using the mean and standard deviation of estimates.
+        Default is True.
+    mlp_widths : Sequence[int], optional
+        Sequence specifying the number of units in each hidden layer of the MLP classifier. Default is (256, 256).
+    **kwargs
+        Additional keyword arguments. Recognized keyword:
+            mlp_kwargs : dict
+                Dictionary of additional parameters to pass to the MLP constructor.
+
+    Returns
+    -------
+    results : float or dict
+        If return_metric_only is True, returns the final validation metric (e.g., accuracy) as a float.
+        Otherwise, returns a dictionary with keys "score", "classifier", and "history", where "score"
+        is the final validation metric, "classifier" is the trained Keras model, and "history" contains the
+        full training history.
+    """
+
+    # Convert tensors to numpy, if passed
+    estimates = keras.ops.convert_to_numpy(estimates)
+    targets = keras.ops.convert_to_numpy(targets)
+
+    # Error, if targets dim does not match estimates dim
+    num_dims = estimates.shape[1]
+    if not num_dims == targets.shape[1]:
+        raise ShapeError(
+            f"estimates and targets can have different number of samples (1st dim)"
+            f"but must have the same dimensionality (2nd dim)"
+            f"found: estimates shape {estimates.shape[1]}, targets shape {targets.shape[1]}"
+        )
+
+    # Standardize both estimates and targets relative to estimates mean and std
+    if standardize:
+        estimates_mean = np.mean(estimates, axis=0)
+        estimates_std = np.std(estimates, axis=0)
+        estimates = (estimates - estimates_mean) / estimates_std
+        targets = (targets - estimates_mean) / estimates_std
+
+    # Create data for classification task
+    data = np.r_[estimates, targets]
+    labels = np.r_[np.zeros((estimates.shape[0],)), np.ones((targets.shape[0],))]
+
+    # Create and train classifier with optional stopping
+    classifier = keras.Sequential(
+        [MLP(widths=mlp_widths, **kwargs.get("mlp_kwargs", {})), keras.layers.Dense(1, activation="sigmoid")]
+    )
+
+    classifier.compile(optimizer="adam", loss="binary_crossentropy", metrics=[metric])
+
+    early_stopping = keras.callbacks.EarlyStopping(
+        monitor=f"val_{metric}", patience=patience, restore_best_weights=True
+    )
+
+    history = classifier.fit(
+        x=data,
+        y=labels,
+        epochs=max_epochs,
+        batch_size=batch_size,
+        verbose=0,
+        callbacks=[early_stopping],
+        validation_split=validation_split,
+    )
+
+    if return_metric_only:
+        return history.history[f"val_{metric}"][-1]
+    return {"score": history.history[f"val_{metric}"][-1], "classifier": classifier, "history": history.history}


### PR DESCRIPTION
Adds classifier two-sample test (C2ST) metric to the `bayesflow.diagnostics.metrics` module. Example usage:

`
samples = ...
reference_samples = ...

# Using default arguments
c2st = classifier_two_sample_test(samples, reference_samples)

# Customizing arguments - will return full classification report + classifier and use a smaller validation data ratio
c2st_dict = classifier_two_sample_test(samples, reference_samples, return_metric_only=False, validation_split=0.2)
`
What we need to discuss is the conceptual separation of metrics, namely those intended to capture the performance of an ensemble of posteriors (e.g., SBC, RMSE) and depend on the prior or those intended to capture the quality of individual posteriors (e.g., MMD, C2ST). Should these two classes of metrics reside in different submodules? @paul-buerkner @vpratz @LarsKue 

Note also, that I removed the internal cross-validation in favor of a simple train-test split. Since the C2ST will generally be computed on different source-target posterior samples, any epistemic uncertainty will average out. However, I could allow K-fold as well with some custom helpers, mainly because I wanted to avoid the explicit dependence on `sklearn`.