### PR TITLE
Force contiguous searchsorted

### DIFF
--- a/bayesflow/__init__.py
+++ b/bayesflow/__init__.py
@@ -40,8 +40,12 @@ def setup():
         torch.autograd.set_grad_enabled(False)
 
         logging.warning(
+            "\n"
             "When using torch backend, we need to disable autograd by default to avoid excessive memory usage. Use\n"
+            "\n"
             "with torch.enable_grad():\n"
+            "    ...\n"
+            "\n"
             "in contexts where you need gradients (e.g. custom training loops)."
         )
 

--- a/bayesflow/utils/tensor_utils.py
+++ b/bayesflow/utils/tensor_utils.py
@@ -202,7 +202,9 @@ def searchsorted(sorted_sequence: Tensor, values: Tensor, side: str = "left") ->
 
             out_int32 = len(sorted_sequence) <= np.iinfo(np.int32).max
 
-            indices = torch.searchsorted(sorted_sequence, values, side=side, out_int32=out_int32)
+            indices = torch.searchsorted(
+                sorted_sequence.contiguous(), values.contiguous(), side=side, out_int32=out_int32
+            )
 
             return indices
         case _:

--- a/bayesflow/workflows/basic_workflow.py
+++ b/bayesflow/workflows/basic_workflow.py
@@ -738,8 +738,14 @@ class BasicWorkflow(Workflow):
             metric evolution over epochs.
         """
 
+        import multiprocessing as mp
+
         dataset = OnlineDataset(
-            simulator=self.simulator, batch_size=batch_size, num_batches=num_batches_per_epoch, adapter=self.adapter
+            simulator=self.simulator,
+            batch_size=batch_size,
+            num_batches=num_batches_per_epoch,
+            adapter=self.adapter,
+            workers=mp.cpu_count(),
         )
 
         return self._fit(

--- a/bayesflow/workflows/basic_workflow.py
+++ b/bayesflow/workflows/basic_workflow.py
@@ -738,14 +738,8 @@ class BasicWorkflow(Workflow):
             metric evolution over epochs.
         """
 
-        import multiprocessing as mp
-
         dataset = OnlineDataset(
-            simulator=self.simulator,
-            batch_size=batch_size,
-            num_batches=num_batches_per_epoch,
-            adapter=self.adapter,
-            workers=mp.cpu_count(),
+            simulator=self.simulator, batch_size=batch_size, num_batches=num_batches_per_epoch, adapter=self.adapter
         )
 
         return self._fit(


### PR DESCRIPTION
Calling `searchsorted` from torch backend sometimes outputs a warning that non-contiguous input tensors reduce performance. We would like to avoid this, so this PR forces input tensors to `searchsorted` to be contiguous in torch.