### PR TITLE
[no ci] docs: fix link to point estimation notebook

### DIFF
--- a/docsrc/source/examples.rst
+++ b/docsrc/source/examples.rst
@@ -16,4 +16,4 @@ The corresponding Jupyter Notebooks are available :mainbranch:`here <examples/>`
    _examples/Bayesian_Experimental_Design.ipynb
    _examples/From_ABC_to_BayesFlow.ipynb
    _examples/One_Sample_TTest.ipynb
-   _examples/Lotka_Volterra_point_estimation_and_expert_stats.ipynb
+   _examples/Lotka_Volterra_Point_Estimation_and_Expert_Stats.ipynb


### PR DESCRIPTION
The file was renamed, which broke the link. This PR fixes this.