### PR TITLE
fix dict utils

### DIFF
--- a/bayesflow/utils/dict_utils.py
+++ b/bayesflow/utils/dict_utils.py
@@ -222,7 +222,7 @@ def make_variable_array(
     else:
         raise TypeError(f"Only dicts and tensors are supported as arguments, but your estimates are of type {type(x)}")
 
-    if len(variable_names) is not x.shape[-1]:
+    if len(variable_names) == x.shape[-1]:
         raise ValueError("Length of 'variable_names' should be the same as the number of variables.")
 
     if variable_keys is None:


### PR DESCRIPTION
The change corrects a conditional statement to ensure proper validation of the length of `variable_names` against the shape of `x`. The previous statement only worked for integer smaller than 255 as `is not` checks for object identity not the values.