### PR TITLE
Set default stage in adapter to "inference"

### DIFF
--- a/bayesflow/adapters/adapter.py
+++ b/bayesflow/adapters/adapter.py
@@ -79,13 +79,15 @@ class Adapter(MutableSequence[Transform]):
     def get_config(self) -> dict:
         return {"transforms": serialize(self.transforms)}
 
-    def forward(self, data: dict[str, any], **kwargs) -> dict[str, np.ndarray]:
+    def forward(self, data: dict[str, any], *, stage: str = "inference", **kwargs) -> dict[str, np.ndarray]:
         """Apply the transforms in the forward direction.
 
         Parameters
         ----------
         data : dict
             The data to be transformed.
+        stage : str, one of ["training", "validation", "inference"]
+            The stage the function is called in.
         **kwargs : dict
             Additional keyword arguments passed to each transform.
 
@@ -97,17 +99,19 @@ class Adapter(MutableSequence[Transform]):
         data = data.copy()
 
         for transform in self.transforms:
-            data = transform(data, **kwargs)
+            data = transform(data, stage=stage, **kwargs)
 
         return data
 
-    def inverse(self, data: dict[str, np.ndarray], **kwargs) -> dict[str, any]:
+    def inverse(self, data: dict[str, np.ndarray], *, stage: str = "inference", **kwargs) -> dict[str, any]:
         """Apply the transforms in the inverse direction.
 
         Parameters
         ----------
         data : dict
             The data to be transformed.
+        stage : str, one of ["training", "validation", "inference"]
+            The stage the function is called in.
         **kwargs : dict
             Additional keyword arguments passed to each transform.
 
@@ -119,11 +123,13 @@ class Adapter(MutableSequence[Transform]):
         data = data.copy()
 
         for transform in reversed(self.transforms):
-            data = transform(data, inverse=True, **kwargs)
+            data = transform(data, stage=stage, inverse=True, **kwargs)
 
         return data
 
-    def __call__(self, data: Mapping[str, any], *, inverse: bool = False, **kwargs) -> dict[str, np.ndarray]:
+    def __call__(
+        self, data: Mapping[str, any], *, inverse: bool = False, stage="inference", **kwargs
+    ) -> dict[str, np.ndarray]:
         """Apply the transforms in the given direction.
 
         Parameters
@@ -132,6 +138,8 @@ class Adapter(MutableSequence[Transform]):
             The data to be transformed.
         inverse : bool, optional
             If False, apply the forward transform, else apply the inverse transform (default False).
+        stage : str, one of ["training", "validation", "inference"]
+            The stage the function is called in.
         **kwargs
             Additional keyword arguments passed to each transform.
 
@@ -141,9 +149,9 @@ class Adapter(MutableSequence[Transform]):
             The transformed data.
         """
         if inverse:
-            return self.inverse(data, **kwargs)
+            return self.inverse(data, stage=stage, **kwargs)
 
-        return self.forward(data, **kwargs)
+        return self.forward(data, stage=stage, **kwargs)
 
     def __repr__(self):
         result = ""

--- a/bayesflow/adapters/transforms/standardize.py
+++ b/bayesflow/adapters/transforms/standardize.py
@@ -96,7 +96,7 @@ class Standardize(ElementwiseTransform):
             "momentum": serialize(self.momentum),
         }
 
-    def forward(self, data: np.ndarray, stage: str = "training", **kwargs) -> np.ndarray:
+    def forward(self, data: np.ndarray, stage: str = "inference", **kwargs) -> np.ndarray:
         if self.axis is None:
             self.axis = tuple(range(data.ndim - 1))
 

--- a/bayesflow/datasets/disk_dataset.py
+++ b/bayesflow/datasets/disk_dataset.py
@@ -31,6 +31,7 @@ class DiskDataset(keras.utils.PyDataset):
         batch_size: int,
         load_fn: callable = None,
         adapter: Adapter | None,
+        stage: str = "training",
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -39,6 +40,7 @@ class DiskDataset(keras.utils.PyDataset):
         self.load_fn = load_fn or pickle_load
         self.adapter = adapter
         self.files = list(map(str, self.root.glob(pattern)))
+        self.stage = stage
 
         self.shuffle()
 
@@ -55,7 +57,7 @@ class DiskDataset(keras.utils.PyDataset):
         batch = tree_stack(batch)
 
         if self.adapter is not None:
-            batch = self.adapter(batch)
+            batch = self.adapter(batch, stage=self.stage)
 
         return batch
 

--- a/bayesflow/datasets/offline_dataset.py
+++ b/bayesflow/datasets/offline_dataset.py
@@ -21,12 +21,15 @@ class OfflineDataset(keras.utils.PyDataset):
         batch_size: int,
         adapter: Adapter | None,
         num_samples: int = None,
+        *,
+        stage: str = "training",
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.batch_size = batch_size
         self.data = data
         self.adapter = adapter
+        self.stage = stage
 
         if num_samples is None:
             self.num_samples = self._get_num_samples_from_data(data)
@@ -52,7 +55,7 @@ class OfflineDataset(keras.utils.PyDataset):
         }
 
         if self.adapter is not None:
-            batch = self.adapter(batch)
+            batch = self.adapter(batch, stage=self.stage)
 
         return batch
 

--- a/bayesflow/datasets/online_dataset.py
+++ b/bayesflow/datasets/online_dataset.py
@@ -16,6 +16,8 @@ class OnlineDataset(keras.utils.PyDataset):
         batch_size: int,
         num_batches: int,
         adapter: Adapter | None,
+        *,
+        stage: str = "training",
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -24,12 +26,13 @@ class OnlineDataset(keras.utils.PyDataset):
         self._num_batches = num_batches
         self.adapter = adapter
         self.simulator = simulator
+        self.stage = stage
 
     def __getitem__(self, item: int) -> dict[str, np.ndarray]:
         batch = self.simulator.sample((self.batch_size,))
 
         if self.adapter is not None:
-            batch = self.adapter(batch)
+            batch = self.adapter(batch, stage=self.stage)
 
         return batch
 

--- a/bayesflow/datasets/rounds_dataset.py
+++ b/bayesflow/datasets/rounds_dataset.py
@@ -18,6 +18,8 @@ class RoundsDataset(keras.utils.PyDataset):
         num_batches: int,
         epochs_per_round: int,
         adapter: Adapter | None,
+        *,
+        stage: str = "training",
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -27,6 +29,7 @@ class RoundsDataset(keras.utils.PyDataset):
         self.batch_size = batch_size
         self.adapter = adapter
         self.epoch = 0
+        self.stage = stage
 
         if epochs_per_round == 1:
             logging.warning(
@@ -45,7 +48,7 @@ class RoundsDataset(keras.utils.PyDataset):
         batch = self.batches[item]
 
         if self.adapter is not None:
-            batch = self.adapter(batch)
+            batch = self.adapter(batch, stage=self.stage)
 
         return batch
 


### PR DESCRIPTION
Concerns #417.
Question:
As Lars already highlighted when creating the current implementation, we cannot pass the stage to the `__getitem__` methods of the datasets. How do we want to handle this?
For now, I have made the stage that will be used configurable in the `__init__` function.
What should its default be? For now, I have set it to "training". The alternative would be to set it to "inference" and dynamically change it to "training" in `Approximator.fit`.
What do you think, @LarsKue and @stefanradev93? Setting this to a draft until we have discussed this...

Minor point: Do we want to convert the stages to an [enum](https://docs.python.org/3/library/enum.html). This would be a bit more typing (but autocomplete should help), and might prevent future bugs due to typos in the strings. Not sure whether it is worth it though, what do you think?