### PR TITLE
overriding simulator outputs with auto-batched inputs

### DIFF
--- a/tests/test_simulators/conftest.py
+++ b/tests/test_simulators/conftest.py
@@ -148,6 +148,35 @@ def two_moons_simulator(request):
     return request.getfixturevalue(request.param)
 
 
+@pytest.fixture()
+def composite_gaussian():
+    from bayesflow.simulators import make_simulator
+
+    def context():
+        n = np.random.randint(10, 100)
+        return dict(n=n)
+
+    def prior():
+        mu = np.random.normal(0, 1)
+        return dict(mu=mu)
+
+    def likelihood(mu, n):
+        y = np.random.normal(mu, 1, n)
+        return dict(y=y)
+
+    return make_simulator([prior, likelihood], meta_fn=context)
+
+
+@pytest.fixture()
+def fixed_n():
+    return 5
+
+
+@pytest.fixture()
+def fixed_mu():
+    return 100
+
+
 @pytest.fixture(
     params=[
         "bernoulli_glm",

--- a/tests/test_simulators/test_simulators.py
+++ b/tests/test_simulators/test_simulators.py
@@ -38,3 +38,12 @@ def test_sample(simulator, batch_size):
 
         # test batch randomness
         assert not np.allclose(value, value[0])
+
+
+def test_fixed_sample(composite_gaussian, batch_size, fixed_n, fixed_mu):
+    samples = composite_gaussian.sample((batch_size,), n=fixed_n, mu=fixed_mu)
+
+    assert samples["n"] == fixed_n
+    assert samples["mu"].shape == (batch_size, 1)
+    assert np.all(samples["mu"] == fixed_mu)
+    assert samples["y"].shape == (batch_size, fixed_n)


### PR DESCRIPTION
fixes https://github.com/bayesflow-org/bayesflow/issues/312

Example

```python
def context():
    n = np.random.randint(10,100)
    return dict(n=n)

def prior(): 
    mu = np.random.normal(0,1)
    return dict(mu=mu)

def likelihood(mu, n):
    y = np.random.normal(mu,1,n)
    return dict(y=y)

simulator = bf.make_simulator([prior, likelihood], meta_fn=context)

simulator.sample(5, n=10, mu=100)
```
yields
```
{'n': 10,
 'mu': array([[100],
        [100],
        [100],
        [100],
        [100]]),
 'y': array([[ 98.90671933, 100.61462062, 100.42855418, 101.29272571,
          99.72418927,  99.37682655, 100.56386549, 100.6960222 ,
          99.68990492,  99.78906661],
        [ 98.30115229,  99.57536366, 100.8883384 ,  99.30972481,
          99.15394186,  99.50626826,  99.84819924,  99.34255664,
          99.72014674, 100.91778608],
        [100.14703062,  97.29856387, 100.26204114, 100.13075532,
          98.46860163,  99.74049941,  99.30891457,  97.92621077,
         100.65618885, 100.32520231],
        [ 99.40222488,  98.65323336, 100.45569538,  99.78072558,
          99.99451661,  99.14487046, 100.01430986, 102.46395478,
         100.37424699, 101.17221606],
        [ 99.82039995,  99.88639318,  98.72186382, 100.3090266 ,
          98.47726752, 100.42259135, 100.5953545 ,  98.9832539 ,
          98.12420365, 102.1115805 ]])}
```