### PR TITLE
Drastically Improve Speed of Import

### DIFF
--- a/tests/test_utils/test_dispatch.py
+++ b/tests/test_utils/test_dispatch.py
@@ -3,6 +3,7 @@ import pytest
 
 # Import the dispatch functions
 from bayesflow.utils import find_network, find_permutation, find_pooling, find_recurrent_net
+from tests.utils import assert_allclose
 
 # --- Tests for find_network.py ---
 
@@ -118,23 +119,21 @@ def test_find_pooling_mean():
     # Check that a keras Lambda layer is returned
     assert isinstance(pooling, keras.layers.Lambda)
     # Test that the lambda function produces a mean when applied to a sample tensor.
-    import numpy as np
 
-    sample = np.array([[1, 2], [3, 4]])
+    sample = keras.ops.convert_to_tensor([[1, 2], [3, 4]])
     # Keras Lambda layers expect tensors via call(), here we simply call the layer's function.
     result = pooling.call(sample)
-    np.testing.assert_allclose(result, sample.mean(axis=-2))
+    assert_allclose(result, keras.ops.mean(sample, axis=-2))
 
 
 @pytest.mark.parametrize("name,func", [("max", keras.ops.max), ("min", keras.ops.min)])
 def test_find_pooling_max_min(name, func):
     pooling = find_pooling(name)
     assert isinstance(pooling, keras.layers.Lambda)
-    import numpy as np
 
-    sample = np.array([[1, 2], [3, 4]])
+    sample = keras.ops.convert_to_tensor([[1, 2], [3, 4]])
     result = pooling.call(sample)
-    np.testing.assert_allclose(result, func(sample, axis=-2))
+    assert_allclose(result, func(sample, axis=-2))
 
 
 def test_find_pooling_learnable(monkeypatch):


### PR DESCRIPTION
Importing BayesFlow has been very slow. Here is an example:

```py3
%%time
import bayesflow as bf
>>> CPU times: user 13 s, sys: 2.62 s, total: 15.6 s
>>> Wall time: 13 s
```

Some of this time is taken up by importing keras, which differs by the backend used:

```py3
%%time
import keras  # using tensorflow backend
>>> CPU times: user 3.88 s, sys: 294 ms, total: 4.17 s
>>> Wall time: 1.55 s
```

Using a simple line-profiler, I could track the issue to `inspect.stack()`, `inspect.getmodule()` and `inspect.ismodule()`. On import, these are primarily used in 2 places:

1. in `_add_imports_to_all()`
2. in `@serializable`

I refactored these utilities to avoid the expensive calls to `inspect`, making the import time now primarily dominated by the import to the respective deep learning framework:

```py3
%%time
import bayesflow as bf
CPU times: user 4.29 s, sys: 819 ms, total: 5.11 s
Wall time: 2.5 s
```

So, for our library, this is a speed-up of approximately $(13s - 1.55s) / (2.5s - 1.55s) \approx 1200$%.


Since this is a sensitive change to the library, I would like to ask that you take extra care when reviewing this. @vpratz I requested your review primarily for the `_add_imports_to_all` function. Could you add a test that checks if it is working correctly? @stefanradev93 I would like you to sign off on merging this as well.