### PR TITLE
Automatically run slow tests when main is involved.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -73,8 +73,11 @@ jobs:
           pytest -x -m "not slow"
 
       - name: Run Slow Tests
-        # run all slow tests only on manual trigger
-        if: github.event_name == 'workflow_dispatch'
+        # Run slow tests on manual trigger and pushes/PRs to main.
+        # Limit to one OS and Python version to save compute.
+        # Multiline if statements are weird, https://github.com/orgs/community/discussions/25641,
+        # but feel free to convert it.
+        if: ${{ ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'pull_request' && github.base_ref == 'main')) && ((matrix.os == 'windows-latest') && (matrix.python-version == '3.10')) }}
         run: |
           pytest -m "slow"
 


### PR DESCRIPTION
In addition, this PR limits the slow test to Windows and Python 3.10. The choices are somewhat arbitrary, my thought was to test the setup not covered as much through use by the devs.

@LarsKue I'm not too familiar with YAML, and the multi-line situation made me not so eager to prettify this. Feel free to clean this up if you know how to change it, but I think it's fine for now in one line as well.