### PR TITLE
`ModelComparisonSimulator`: handle different outputs from individual simulators

### DIFF
--- a/bayesflow/simulators/model_comparison_simulator.py
+++ b/bayesflow/simulators/model_comparison_simulator.py
@@ -42,10 +42,12 @@ class ModelComparisonSimulator(Simulator):
             If neither `p` nor `logits` is provided, defaults to uniform logits.
         use_mixed_batches : bool, optional
             Whether to draw samples in a batch from different models.
+
             - If True (default), each sample in a batch may come from a different model.
             - If False, the entire batch is drawn from a single model, selected according to model probabilities.
         key_conflicts : str, optional
             Policy for handling keys that are missing in the output of some models, when using mixed batches.
+
             - "drop" (default): Drop conflicting keys from the batch output.
             - "fill": Fill missing keys with the specified value.
             - "error": An error is raised when key conflicts are detected.
@@ -53,7 +55,7 @@ class ModelComparisonSimulator(Simulator):
             If `key_conflicts=="fill"`, the missing keys will be filled with the value of this argument.
         shared_simulator : Simulator or Callable, optional
             A shared simulator whose outputs are passed to all model simulators. If a function is
-            provided, it is wrapped in a `LambdaSimulator` with batching enabled.
+            provided, it is wrapped in a :py:class:`~bayesflow.simulators.LambdaSimulator` with batching enabled.
         """
         self.simulators = simulators
 

--- a/bayesflow/simulators/model_comparison_simulator.py
+++ b/bayesflow/simulators/model_comparison_simulator.py
@@ -9,6 +9,7 @@ from bayesflow.utils import numpy_utils as npu
 from bayesflow.utils import logging
 
 from types import FunctionType
+from typing import Literal
 
 from .simulator import Simulator
 from .lambda_simulator import LambdaSimulator
@@ -23,7 +24,7 @@ class ModelComparisonSimulator(Simulator):
         p: Sequence[float] = None,
         logits: Sequence[float] = None,
         use_mixed_batches: bool = True,
-        key_conflicts: str = "drop",
+        key_conflicts: Literal["drop", "fill", "error"] = "drop",
         fill_value: float = np.nan,
         shared_simulator: Simulator | Callable[[Sequence[int]], dict[str, any]] = None,
     ):
@@ -160,7 +161,9 @@ class ModelComparisonSimulator(Simulator):
                     sim[missing_key] = np.full(shape=shape, fill_value=self.fill_value)
             return sims
         elif self.key_conflicts == "error":
-            raise ValueError("Key conflicts are found in simulator outputs, cannot combine them into one batch.")
+            raise ValueError(
+                "Different simulators provide outputs with different keys, cannot combine them into one batch."
+            )
 
     def _determine_key_conflicts(self, sims):
         keys = [set(sim.keys()) for sim in sims]

--- a/bayesflow/simulators/model_comparison_simulator.py
+++ b/bayesflow/simulators/model_comparison_simulator.py
@@ -144,7 +144,7 @@ class ModelComparisonSimulator(Simulator):
             sims = [{k: v for k, v in sim.items() if k in common_keys} for sim in sims]
             return sims
 
-        # try to fill values with key_conflicts to shape of sims from other models
+        # try to fill with key_conflicts to shape of the values from other model
         if isinstance(self.key_conflicts, (float, int)):
             combined_sims = {}
             for sim in sims:
@@ -153,7 +153,7 @@ class ModelComparisonSimulator(Simulator):
             for i, sim in enumerate(sims):
                 for missing_key in missing_keys[i]:
                     shape = combined_sims[missing_key].shape
-                    shape = [s for s in shape]
+                    shape = list(shape)
                     shape[0] = batch_sizes[i]
 
                     sim[missing_key] = np.full(shape=shape, fill_value=self.key_conflicts)

--- a/tests/test_simulators/conftest.py
+++ b/tests/test_simulators/conftest.py
@@ -167,8 +167,32 @@ def composite_gaussian():
     return make_simulator([prior, likelihood], meta_fn=context)
 
 
-@pytest.fixture(params=["drop", np.nan])
-def multimodel(request):
+@pytest.fixture()
+def multimodel():
+    from bayesflow.simulators import make_simulator, ModelComparisonSimulator
+
+    def context(batch_size):
+        return dict(n=np.random.randint(10, 100))
+
+    def prior_0():
+        return dict(mu=0)
+
+    def prior_1():
+        return dict(mu=np.random.standard_normal())
+
+    def likelihood(n, mu):
+        return dict(y=np.random.normal(mu, 1, n))
+
+    simulator_0 = make_simulator([prior_0, likelihood])
+    simulator_1 = make_simulator([prior_1, likelihood])
+
+    simulator = ModelComparisonSimulator(simulators=[simulator_0, simulator_1], shared_simulator=context)
+
+    return simulator
+
+
+@pytest.fixture(params=["drop", "fill", "error"])
+def multimodel_key_conflicts(request):
     from bayesflow.simulators import make_simulator, ModelComparisonSimulator
 
     rng = np.random.default_rng()

--- a/tests/test_simulators/conftest.py
+++ b/tests/test_simulators/conftest.py
@@ -167,6 +167,32 @@ def composite_gaussian():
     return make_simulator([prior, likelihood], meta_fn=context)
 
 
+@pytest.fixture(params=["drop", np.nan])
+def multimodel(request):
+    from bayesflow.simulators import make_simulator, ModelComparisonSimulator
+
+    rng = np.random.default_rng()
+
+    def prior_1():
+        return dict(w=rng.uniform())
+
+    def prior_2():
+        return dict(c=rng.uniform())
+
+    def model_1(w):
+        return dict(x=w)
+
+    def model_2(c):
+        return dict(x=c)
+
+    simulator_1 = make_simulator([prior_1, model_1])
+    simulator_2 = make_simulator([prior_2, model_2])
+
+    simulator = ModelComparisonSimulator(simulators=[simulator_1, simulator_2], key_conflicts=request.param)
+
+    return simulator
+
+
 @pytest.fixture()
 def fixed_n():
     return 5

--- a/tests/test_simulators/test_simulators.py
+++ b/tests/test_simulators/test_simulators.py
@@ -47,3 +47,13 @@ def test_fixed_sample(composite_gaussian, batch_size, fixed_n, fixed_mu):
     assert samples["mu"].shape == (batch_size, 1)
     assert np.all(samples["mu"] == fixed_mu)
     assert samples["y"].shape == (batch_size, fixed_n)
+
+
+def test_multimodel_sample(multimodel, batch_size):
+    samples = multimodel.sample(batch_size)
+
+    if multimodel.key_conflicts == "drop":
+        assert set(samples) == {"x", "model_indices"}
+    else:
+        assert set(samples) == {"x", "model_indices", "c", "w"}
+        assert np.sum(np.isnan(samples["c"])) + np.sum(np.isnan(samples["w"])) == batch_size

--- a/tests/test_simulators/test_simulators.py
+++ b/tests/test_simulators/test_simulators.py
@@ -1,3 +1,4 @@
+import pytest
 import keras
 import numpy as np
 
@@ -52,8 +53,19 @@ def test_fixed_sample(composite_gaussian, batch_size, fixed_n, fixed_mu):
 def test_multimodel_sample(multimodel, batch_size):
     samples = multimodel.sample(batch_size)
 
-    if multimodel.key_conflicts == "drop":
+    assert set(samples) == {"n", "mu", "y", "model_indices"}
+    assert samples["mu"].shape == (batch_size, 1)
+    assert samples["y"].shape == (batch_size, samples["n"])
+
+
+def test_multimodel_key_conflicts_sample(multimodel_key_conflicts, batch_size):
+    if multimodel_key_conflicts.key_conflicts == "drop":
+        samples = multimodel_key_conflicts.sample(batch_size)
         assert set(samples) == {"x", "model_indices"}
-    else:
+    elif multimodel_key_conflicts.key_conflicts == "fill":
+        samples = multimodel_key_conflicts.sample(batch_size)
         assert set(samples) == {"x", "model_indices", "c", "w"}
         assert np.sum(np.isnan(samples["c"])) + np.sum(np.isnan(samples["w"])) == batch_size
+    elif multimodel_key_conflicts.key_conflicts == "error":
+        with pytest.raises(Exception):
+            samples = multimodel_key_conflicts.sample(batch_size)

--- a/tests/test_simulators/test_simulators.py
+++ b/tests/test_simulators/test_simulators.py
@@ -67,5 +67,5 @@ def test_multimodel_key_conflicts_sample(multimodel_key_conflicts, batch_size):
         assert set(samples) == {"x", "model_indices", "c", "w"}
         assert np.sum(np.isnan(samples["c"])) + np.sum(np.isnan(samples["w"])) == batch_size
     elif multimodel_key_conflicts.key_conflicts == "error":
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             samples = multimodel_key_conflicts.sample(batch_size)


### PR DESCRIPTION
fixes https://github.com/bayesflow-org/bayesflow/issues/441

As per https://github.com/bayesflow-org/bayesflow/issues/441#issuecomment-2830285318, this PR implements

> "smarter" concatenation function (for example one that pads with nan if a parameter is not available for a given model). 

However, by default the simulator will just drop (with an info warning) keys that are not common for all simulators, since in most situations we would not need those outputs in the first place.