### PR TITLE
Fix redirects from old docs to stable-legacy

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install -U pip setuptools wheel
+          python -m pip install -U pip setuptools wheel
           pip install .[test]
 
       - name: Install JAX

--- a/docsrc/polyversion/templates/_examples/Amortized_Point_Estimation.html
+++ b/docsrc/polyversion/templates/_examples/Amortized_Point_Estimation.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_examples/Amortized_Point_Estimation.html"
+            content="0; url=/stable-legacy/_examples/Amortized_Point_Estimation.html"
         />
-        <link rel="canonical" href="/v1.1.6/_examples/Amortized_Point_Estimation.html" />
+        <link rel="canonical" href="/stable-legacy/_examples/Amortized_Point_Estimation.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_examples/Covid19_Initial_Posterior_Estimation.html
+++ b/docsrc/polyversion/templates/_examples/Covid19_Initial_Posterior_Estimation.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_examples/Covid19_Initial_Posterior_Estimation.html"
+            content="0; url=/stable-legacy/_examples/Covid19_Initial_Posterior_Estimation.html"
         />
-        <link rel="canonical" href="/v1.1.6/_examples/Covid19_Initial_Posterior_Estimation.html" />
+        <link rel="canonical" href="/stable-legacy/_examples/Covid19_Initial_Posterior_Estimation.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_examples/Hierarchical_Model_Comparison_MPT.html
+++ b/docsrc/polyversion/templates/_examples/Hierarchical_Model_Comparison_MPT.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_examples/Hierarchical_Model_Comparison_MPT.html"
+            content="0; url=/stable-legacy/_examples/Hierarchical_Model_Comparison_MPT.html"
         />
-        <link rel="canonical" href="/v1.1.6/_examples/Hierarchical_Model_Comparison_MPT.html" />
+        <link rel="canonical" href="/stable-legacy/_examples/Hierarchical_Model_Comparison_MPT.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_examples/Intro_Amortized_Posterior_Estimation.html
+++ b/docsrc/polyversion/templates/_examples/Intro_Amortized_Posterior_Estimation.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_examples/Intro_Amortized_Posterior_Estimation.html"
+            content="0; url=/stable-legacy/_examples/Intro_Amortized_Posterior_Estimation.html"
         />
-        <link rel="canonical" href="/v1.1.6/_examples/Intro_Amortized_Posterior_Estimation.html" />
+        <link rel="canonical" href="/stable-legacy/_examples/Intro_Amortized_Posterior_Estimation.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_examples/LCA_Model_Posterior_Estimation.html
+++ b/docsrc/polyversion/templates/_examples/LCA_Model_Posterior_Estimation.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_examples/LCA_Model_Posterior_Estimation.html"
+            content="0; url=/stable-legacy/_examples/LCA_Model_Posterior_Estimation.html"
         />
-        <link rel="canonical" href="/v1.1.6/_examples/LCA_Model_Posterior_Estimation.html" />
+        <link rel="canonical" href="/stable-legacy/_examples/LCA_Model_Posterior_Estimation.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_examples/Linear_ODE_system.html
+++ b/docsrc/polyversion/templates/_examples/Linear_ODE_system.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_examples/Linear_ODE_system.html"
+            content="0; url=/stable-legacy/_examples/Linear_ODE_system.html"
         />
-        <link rel="canonical" href="/v1.1.6/_examples/Linear_ODE_system.html" />
+        <link rel="canonical" href="/stable-legacy/_examples/Linear_ODE_system.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_examples/Model_Comparison_MPT.html
+++ b/docsrc/polyversion/templates/_examples/Model_Comparison_MPT.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_examples/Model_Comparison_MPT.html"
+            content="0; url=/stable-legacy/_examples/Model_Comparison_MPT.html"
         />
-        <link rel="canonical" href="/v1.1.6/_examples/Model_Comparison_MPT.html" />
+        <link rel="canonical" href="/stable-legacy/_examples/Model_Comparison_MPT.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_examples/Model_Misspecification.html
+++ b/docsrc/polyversion/templates/_examples/Model_Misspecification.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_examples/Model_Misspecification.html"
+            content="0; url=/stable-legacy/_examples/Model_Misspecification.html"
         />
-        <link rel="canonical" href="/v1.1.6/_examples/Model_Misspecification.html" />
+        <link rel="canonical" href="/stable-legacy/_examples/Model_Misspecification.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_examples/TwoMoons_Bimodal_Posterior.html
+++ b/docsrc/polyversion/templates/_examples/TwoMoons_Bimodal_Posterior.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_examples/TwoMoons_Bimodal_Posterior.html"
+            content="0; url=/stable-legacy/_examples/TwoMoons_Bimodal_Posterior.html"
         />
-        <link rel="canonical" href="/v1.1.6/_examples/TwoMoons_Bimodal_Posterior.html" />
+        <link rel="canonical" href="/stable-legacy/_examples/TwoMoons_Bimodal_Posterior.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/amortizers.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/amortizers.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/amortizers.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/amortizers.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/amortizers.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/amortizers.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/attention.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/attention.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/attention.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/attention.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/attention.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/attention.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/bernoulli_glm.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/bernoulli_glm.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks/bernoulli_glm.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks/bernoulli_glm.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks/bernoulli_glm.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks/bernoulli_glm.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/bernoulli_glm_raw.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/bernoulli_glm_raw.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks/bernoulli_glm_raw.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks/bernoulli_glm_raw.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks/bernoulli_glm_raw.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks/bernoulli_glm_raw.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/gaussian_linear.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/gaussian_linear.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks/gaussian_linear.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks/gaussian_linear.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks/gaussian_linear.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks/gaussian_linear.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/gaussian_linear_uniform.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/gaussian_linear_uniform.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks/gaussian_linear_uniform.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks/gaussian_linear_uniform.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks/gaussian_linear_uniform.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks/gaussian_linear_uniform.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/gaussian_mixture.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/gaussian_mixture.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks/gaussian_mixture.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks/gaussian_mixture.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks/gaussian_mixture.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks/gaussian_mixture.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/inverse_kinematics.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/inverse_kinematics.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks/inverse_kinematics.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks/inverse_kinematics.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks/inverse_kinematics.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks/inverse_kinematics.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/lotka_volterra.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/lotka_volterra.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks/lotka_volterra.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks/lotka_volterra.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks/lotka_volterra.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks/lotka_volterra.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/sir.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/sir.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks/sir.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks/sir.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks/sir.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks/sir.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/slcp.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/slcp.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks/slcp.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks/slcp.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks/slcp.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks/slcp.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/slcp_distractors.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/slcp_distractors.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks/slcp_distractors.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks/slcp_distractors.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks/slcp_distractors.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks/slcp_distractors.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/two_moons.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/benchmarks/two_moons.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/benchmarks/two_moons.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/benchmarks/two_moons.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/benchmarks/two_moons.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/benchmarks/two_moons.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/computational_utilities.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/computational_utilities.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/computational_utilities.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/computational_utilities.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/computational_utilities.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/computational_utilities.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/configuration.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/configuration.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/configuration.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/configuration.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/configuration.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/configuration.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/coupling_networks.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/coupling_networks.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/coupling_networks.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/coupling_networks.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/coupling_networks.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/coupling_networks.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/default_settings.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/default_settings.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/default_settings.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/default_settings.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/default_settings.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/default_settings.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/diagnostics.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/diagnostics.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/diagnostics.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/diagnostics.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/diagnostics.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/diagnostics.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/exceptions.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/exceptions.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/exceptions.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/exceptions.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/exceptions.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/exceptions.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/experimental/rectifiers.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/experimental/rectifiers.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/experimental/rectifiers.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/experimental/rectifiers.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/experimental/rectifiers.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/experimental/rectifiers.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/helper_classes.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/helper_classes.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/helper_classes.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/helper_classes.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/helper_classes.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/helper_classes.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/helper_functions.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/helper_functions.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/helper_functions.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/helper_functions.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/helper_functions.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/helper_functions.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/helper_networks.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/helper_networks.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/helper_networks.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/helper_networks.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/helper_networks.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/helper_networks.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/inference_networks.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/inference_networks.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/inference_networks.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/inference_networks.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/inference_networks.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/inference_networks.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/losses.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/losses.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/losses.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/losses.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/losses.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/losses.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/mcmc.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/mcmc.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/mcmc.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/mcmc.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/mcmc.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/mcmc.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/sensitivity.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/sensitivity.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/sensitivity.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/sensitivity.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/sensitivity.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/sensitivity.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/simulation.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/simulation.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/simulation.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/simulation.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/simulation.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/simulation.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/summary_networks.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/summary_networks.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/summary_networks.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/summary_networks.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/summary_networks.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/summary_networks.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/trainers.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/trainers.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/trainers.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/trainers.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/trainers.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/trainers.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/_modules/bayesflow/wrappers.html
+++ b/docsrc/polyversion/templates/_modules/bayesflow/wrappers.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/_modules/bayesflow/wrappers.html"
+            content="0; url=/stable-legacy/_modules/bayesflow/wrappers.html"
         />
-        <link rel="canonical" href="/v1.1.6/_modules/bayesflow/wrappers.html" />
+        <link rel="canonical" href="/stable-legacy/_modules/bayesflow/wrappers.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.amortizers.html
+++ b/docsrc/polyversion/templates/api/bayesflow.amortizers.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.amortizers.html"
+            content="0; url=/stable-legacy/api/bayesflow.amortizers.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.amortizers.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.amortizers.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.attention.html
+++ b/docsrc/polyversion/templates/api/bayesflow.attention.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.attention.html"
+            content="0; url=/stable-legacy/api/bayesflow.attention.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.attention.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.attention.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.bernoulli_glm.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.bernoulli_glm.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.bernoulli_glm.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.bernoulli_glm.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.bernoulli_glm.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.bernoulli_glm.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.bernoulli_glm_raw.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.bernoulli_glm_raw.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.bernoulli_glm_raw.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.bernoulli_glm_raw.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.bernoulli_glm_raw.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.bernoulli_glm_raw.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.gaussian_linear.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.gaussian_linear.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.gaussian_linear.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.gaussian_linear.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.gaussian_linear.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.gaussian_linear.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.gaussian_linear_uniform.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.gaussian_linear_uniform.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.gaussian_linear_uniform.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.gaussian_linear_uniform.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.gaussian_linear_uniform.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.gaussian_linear_uniform.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.gaussian_mixture.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.gaussian_mixture.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.gaussian_mixture.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.gaussian_mixture.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.gaussian_mixture.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.gaussian_mixture.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.inverse_kinematics.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.inverse_kinematics.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.inverse_kinematics.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.inverse_kinematics.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.inverse_kinematics.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.inverse_kinematics.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.lotka_volterra.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.lotka_volterra.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.lotka_volterra.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.lotka_volterra.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.lotka_volterra.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.lotka_volterra.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.sir.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.sir.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.sir.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.sir.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.sir.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.sir.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.slcp.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.slcp.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.slcp.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.slcp.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.slcp.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.slcp.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.slcp_distractors.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.slcp_distractors.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.slcp_distractors.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.slcp_distractors.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.slcp_distractors.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.slcp_distractors.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.benchmarks.two_moons.html
+++ b/docsrc/polyversion/templates/api/bayesflow.benchmarks.two_moons.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.benchmarks.two_moons.html"
+            content="0; url=/stable-legacy/api/bayesflow.benchmarks.two_moons.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.benchmarks.two_moons.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.benchmarks.two_moons.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.computational_utilities.html
+++ b/docsrc/polyversion/templates/api/bayesflow.computational_utilities.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.computational_utilities.html"
+            content="0; url=/stable-legacy/api/bayesflow.computational_utilities.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.computational_utilities.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.computational_utilities.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.configuration.html
+++ b/docsrc/polyversion/templates/api/bayesflow.configuration.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.configuration.html"
+            content="0; url=/stable-legacy/api/bayesflow.configuration.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.configuration.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.configuration.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.coupling_networks.html
+++ b/docsrc/polyversion/templates/api/bayesflow.coupling_networks.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.coupling_networks.html"
+            content="0; url=/stable-legacy/api/bayesflow.coupling_networks.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.coupling_networks.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.coupling_networks.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.default_settings.html
+++ b/docsrc/polyversion/templates/api/bayesflow.default_settings.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.default_settings.html"
+            content="0; url=/stable-legacy/api/bayesflow.default_settings.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.default_settings.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.default_settings.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.diagnostics.html
+++ b/docsrc/polyversion/templates/api/bayesflow.diagnostics.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.diagnostics.html"
+            content="0; url=/stable-legacy/api/bayesflow.diagnostics.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.diagnostics.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.diagnostics.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.exceptions.html
+++ b/docsrc/polyversion/templates/api/bayesflow.exceptions.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.exceptions.html"
+            content="0; url=/stable-legacy/api/bayesflow.exceptions.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.exceptions.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.exceptions.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.experimental.html
+++ b/docsrc/polyversion/templates/api/bayesflow.experimental.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.experimental.html"
+            content="0; url=/stable-legacy/api/bayesflow.experimental.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.experimental.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.experimental.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.experimental.rectifiers.html
+++ b/docsrc/polyversion/templates/api/bayesflow.experimental.rectifiers.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.experimental.rectifiers.html"
+            content="0; url=/stable-legacy/api/bayesflow.experimental.rectifiers.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.experimental.rectifiers.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.experimental.rectifiers.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.helper_classes.html
+++ b/docsrc/polyversion/templates/api/bayesflow.helper_classes.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.helper_classes.html"
+            content="0; url=/stable-legacy/api/bayesflow.helper_classes.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.helper_classes.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.helper_classes.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.helper_functions.html
+++ b/docsrc/polyversion/templates/api/bayesflow.helper_functions.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.helper_functions.html"
+            content="0; url=/stable-legacy/api/bayesflow.helper_functions.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.helper_functions.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.helper_functions.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.helper_networks.html
+++ b/docsrc/polyversion/templates/api/bayesflow.helper_networks.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.helper_networks.html"
+            content="0; url=/stable-legacy/api/bayesflow.helper_networks.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.helper_networks.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.helper_networks.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.html
+++ b/docsrc/polyversion/templates/api/bayesflow.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.html"
+            content="0; url=/stable-legacy/api/bayesflow.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.inference_networks.html
+++ b/docsrc/polyversion/templates/api/bayesflow.inference_networks.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.inference_networks.html"
+            content="0; url=/stable-legacy/api/bayesflow.inference_networks.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.inference_networks.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.inference_networks.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.losses.html
+++ b/docsrc/polyversion/templates/api/bayesflow.losses.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.losses.html"
+            content="0; url=/stable-legacy/api/bayesflow.losses.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.losses.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.losses.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.mcmc.html
+++ b/docsrc/polyversion/templates/api/bayesflow.mcmc.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.mcmc.html"
+            content="0; url=/stable-legacy/api/bayesflow.mcmc.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.mcmc.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.mcmc.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.networks.html
+++ b/docsrc/polyversion/templates/api/bayesflow.networks.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.networks.html"
+            content="0; url=/stable-legacy/api/bayesflow.networks.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.networks.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.networks.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.sensitivity.html
+++ b/docsrc/polyversion/templates/api/bayesflow.sensitivity.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.sensitivity.html"
+            content="0; url=/stable-legacy/api/bayesflow.sensitivity.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.sensitivity.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.sensitivity.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.simulation.html
+++ b/docsrc/polyversion/templates/api/bayesflow.simulation.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.simulation.html"
+            content="0; url=/stable-legacy/api/bayesflow.simulation.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.simulation.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.simulation.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.summary_networks.html
+++ b/docsrc/polyversion/templates/api/bayesflow.summary_networks.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.summary_networks.html"
+            content="0; url=/stable-legacy/api/bayesflow.summary_networks.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.summary_networks.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.summary_networks.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.trainers.html
+++ b/docsrc/polyversion/templates/api/bayesflow.trainers.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.trainers.html"
+            content="0; url=/stable-legacy/api/bayesflow.trainers.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.trainers.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.trainers.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.version.html
+++ b/docsrc/polyversion/templates/api/bayesflow.version.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.version.html"
+            content="0; url=/stable-legacy/api/bayesflow.version.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.version.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.version.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/api/bayesflow.wrappers.html
+++ b/docsrc/polyversion/templates/api/bayesflow.wrappers.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/api/bayesflow.wrappers.html"
+            content="0; url=/stable-legacy/api/bayesflow.wrappers.html"
         />
-        <link rel="canonical" href="/v1.1.6/api/bayesflow.wrappers.html" />
+        <link rel="canonical" href="/stable-legacy/api/bayesflow.wrappers.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/examples.html
+++ b/docsrc/polyversion/templates/examples.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/examples.html"
+            content="0; url=/stable-legacy/examples.html"
         />
-        <link rel="canonical" href="/v1.1.6/examples.html" />
+        <link rel="canonical" href="/stable-legacy/examples.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/genindex.html
+++ b/docsrc/polyversion/templates/genindex.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/genindex.html"
+            content="0; url=/stable-legacy/genindex.html"
         />
-        <link rel="canonical" href="/v1.1.6/genindex.html" />
+        <link rel="canonical" href="/stable-legacy/genindex.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/index.html
+++ b/docsrc/polyversion/templates/index.html
@@ -1,12 +1,9 @@
 <!doctype html>
 <html>
-    <head>
+  <head>
     <title>Redirecting to {{ latest.name }} branch/version</title>
-        <meta charset="utf-8" />
-        <meta
-            http-equiv="refresh"
-            content="0; url=/{{ latest.name }}/index.html"
-        />
-        <link rel="canonical" href="/{{ latest.name }}/index.html" />
-    </head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=/{{ latest.name }}/index.html" />
+    <link rel="canonical" href="/{{ latest.name }}/index.html" />
+  </head>
 </html>

--- a/docsrc/polyversion/templates/installation.html
+++ b/docsrc/polyversion/templates/installation.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/installation.html"
+            content="0; url=/stable-legacy/installation.html"
         />
-        <link rel="canonical" href="/v1.1.6/installation.html" />
+        <link rel="canonical" href="/stable-legacy/installation.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/py-modindex.html
+++ b/docsrc/polyversion/templates/py-modindex.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/py-modindex.html"
+            content="0; url=/stable-legacy/py-modindex.html"
         />
-        <link rel="canonical" href="/v1.1.6/py-modindex.html" />
+        <link rel="canonical" href="/stable-legacy/py-modindex.html" />
     </head>
 </html>

--- a/docsrc/polyversion/templates/search.html
+++ b/docsrc/polyversion/templates/search.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
     <head>
-    <title>Redirecting to v1.1.6</title>
+    <title>Redirecting to stable-legacy</title>
         <meta charset="utf-8" />
         <meta
             http-equiv="refresh"
-            content="0; url=/v1.1.6/search.html"
+            content="0; url=/stable-legacy/search.html"
         />
-        <link rel="canonical" href="/v1.1.6/search.html" />
+        <link rel="canonical" href="/stable-legacy/search.html" />
     </head>
 </html>


### PR DESCRIPTION
The redirects went to v1.1.6, but we have chosen the name `stable-legacy` for the old docs instead. This PR adjusts the links in the files used for the redirects.