### PR TITLE
Pin dependencies in docs, fixes snowballstemmer error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,15 @@ all = [
     "ruff",
     "tox",
     # docs
-    "myst-nb",
-    "numpydoc",
-    "pydata-sphinx-theme",
-    "sphinx",
-    "sphinx-polyversion >= 1.1",
-    "sphinx_design",
-    "sphinxcontrib-bibtex",
+
+    "myst-nb ~= 1.2",
+    "numpydoc ~= 1.8",
+    "pydata-sphinx-theme ~= 0.16",
+    "sphinx ~= 8.2",
+    "sphinx-polyversion == 1.1",
+    "sphinx_design ~= 0.6",
+    "sphinxcontrib-bibtex ~= 2.6",
+    "snowballstemmer ~= 2.2.0",
     # test
     "pytest",
     "pytest-cov",
@@ -65,13 +67,14 @@ dev = [
     "tox",
 ]
 docs = [
-    "myst-nb",
-    "numpydoc",
-    "pydata-sphinx-theme",
-    "sphinx",
-    "sphinx-polyversion >= 1.1",
-    "sphinx_design",
-    "sphinxcontrib-bibtex",
+    "myst-nb ~= 1.2",
+    "numpydoc ~= 1.8",
+    "pydata-sphinx-theme ~= 0.16",
+    "sphinx ~= 8.2",
+    "sphinx-polyversion == 1.1",
+    "sphinx_design ~= 0.6",
+    "sphinxcontrib-bibtex ~= 2.6",
+    "snowballstemmer ~= 2.2.0",
 ]
 test = [
     "nbconvert",


### PR DESCRIPTION
Docs were failing because one dependency was silently updated. This PR pins the doc to the correct version.