### PR TITLE
Fixed Jacobian computation of standardize transform

### DIFF
--- a/bayesflow/adapters/transforms/standardize.py
+++ b/bayesflow/adapters/transforms/standardize.py
@@ -123,7 +123,7 @@ class Standardize(ElementwiseTransform):
 
     def log_det_jac(self, data, inverse: bool = False, **kwargs) -> np.ndarray:
         std = np.broadcast_to(self.std, data.shape)
-        ldj = np.log(np.abs(std))
+        ldj = -np.log(np.abs(std))
         if inverse:
             ldj = -ldj
         return np.sum(ldj, axis=tuple(range(1, ldj.ndim)))


### PR DESCRIPTION
I believe the Jacobian computation of standardize should have reversed sign. 

y = (x - mu) / sigma
log p(y) = log p(x) - log(sigma)

Calling the adapter in forward direction should substract log(sigma), while inverse direction should add log(sigma).

Current implementation is switched. The PR fixes that.

BTW: It's really nice that Jacobian tracking adapter exists now in BF, thanks so much!