### PR TITLE
Correctly track train / validation losses

### DIFF
--- a/bayesflow/approximators/approximator.py
+++ b/bayesflow/approximators/approximator.py
@@ -142,7 +142,8 @@ class Approximator(BackendApproximator):
         """Obtain the batch size from a batch of data.
 
         To properly weight the metrics for batches of different sizes, the batch size of a given batch of data is
-        required. As the data structure differs between approximators, each approximator has to specify this method.
+        required. As the data structure differs between approximators, each concrete approximator has to specify
+        this method.
 
         Parameters
         ----------

--- a/bayesflow/approximators/approximator.py
+++ b/bayesflow/approximators/approximator.py
@@ -1,5 +1,3 @@
-from collections.abc import Mapping
-
 import multiprocessing as mp
 
 import keras
@@ -22,7 +20,7 @@ class Approximator(BackendApproximator):
         # implemented by each respective architecture
         raise NotImplementedError
 
-    def build_from_data(self, data: Mapping[str, any]) -> None:
+    def build_from_data(self, data: dict[str, any]) -> None:
         self.compute_metrics(**filter_kwargs(data, self.compute_metrics), stage="training")
         self.built = True
 
@@ -137,27 +135,3 @@ class Approximator(BackendApproximator):
             self.build_from_data(mock_data)
 
         return super().fit(dataset=dataset, **kwargs)
-
-    def _batch_size_from_data(self, data: any):
-        """Obtain the batch size from a batch of data.
-
-        To properly weight the metrics for batches of different sizes, the batch size of a given batch of data is
-        required. As the data structure differs between approximators, each concrete approximator has to specify
-        this method.
-
-        Parameters
-        ----------
-        data :
-            The data that are passed to `compute_metrics` as keyword arguments.
-
-        Returns
-        -------
-        batch_size : int
-            The batch size of the given data.
-        """
-        raise NotImplementedError(
-            "Correct calculation of the metrics requires obtaining the batch size from the supplied data "
-            "for proper weighting of metrics for batches with different sizes. Please implement the "
-            "_batch_size_from_data method for your approximator. For a given batch of data, it should "
-            "return the corresponding batch size."
-        )

--- a/bayesflow/approximators/approximator.py
+++ b/bayesflow/approximators/approximator.py
@@ -137,3 +137,26 @@ class Approximator(BackendApproximator):
             self.build_from_data(mock_data)
 
         return super().fit(dataset=dataset, **kwargs)
+
+    def _batch_size_from_data(self, data: any):
+        """Obtain the batch size from a batch of data.
+
+        To properly weight the metrics for batches of different sizes, the batch size of a given batch of data is
+        required. As the data structure differs between approximators, each approximator has to specify this method.
+
+        Parameters
+        ----------
+        data :
+            The data that are passed to `compute_metrics` as keyword arguments.
+
+        Returns
+        -------
+        batch_size : int
+            The batch size of the given data.
+        """
+        raise NotImplementedError(
+            "Correct calculation of the metrics requires obtaining the batch size from the supplied data "
+            "for proper weighting of metrics for batches with different sizes. Please implement the "
+            "_batch_size_from_data method for your approximator. For a given batch of data, it should "
+            "return the corresponding batch size."
+        )

--- a/bayesflow/approximators/backend_approximators/jax_approximator.py
+++ b/bayesflow/approximators/backend_approximators/jax_approximator.py
@@ -31,7 +31,7 @@ class JAXApproximator(keras.Model):
         ----------
         *args : tuple
             Positional arguments passed to the metric computation function.
-        **kwargs : dict
+        **kwargs
             Keyword arguments passed to the metric computation function.
 
         Returns
@@ -222,3 +222,28 @@ class JAXApproximator(keras.Model):
         metrics_variables = [scope.get_current_value(v) for v in self.metrics_variables]
 
         return metrics_variables
+
+    # noinspection PyMethodOverriding
+    def _batch_size_from_data(self, data: any) -> int:
+        """Obtain the batch size from a batch of data.
+
+        To properly weigh the metrics for batches of different sizes, the batch size of a given batch of data is
+        required. As the data structure differs between approximators, each concrete approximator has to specify
+        this method.
+
+        Parameters
+        ----------
+        data :
+            The data that are passed to `compute_metrics` as keyword arguments.
+
+        Returns
+        -------
+        batch_size : int
+            The batch size of the given data.
+        """
+        raise NotImplementedError(
+            "Correct calculation of the metrics requires obtaining the batch size from the supplied data "
+            "for proper weighting of metrics for batches with different sizes. Please implement the "
+            "_batch_size_from_data method for your approximator. For a given batch of data, it should "
+            "return the corresponding batch size."
+        )

--- a/bayesflow/approximators/backend_approximators/jax_approximator.py
+++ b/bayesflow/approximators/backend_approximators/jax_approximator.py
@@ -5,9 +5,40 @@ from bayesflow.utils import filter_kwargs
 
 
 class JAXApproximator(keras.Model):
+    """
+    Base class for approximators using JAX and Keras' stateless training interface.
+
+    This class enables stateless training and evaluation steps with JAX, supporting
+    JAX-compatible gradient computation and variable updates through the `StatelessScope`.
+
+    Notes
+    -----
+    Subclasses must implement:
+        - compute_metrics(self, *args, **kwargs) -> dict[str, jax.Array]
+        - _batch_size_from_data(self, data: dict[str, any]) -> int
+    """
+
     # noinspection PyMethodOverriding
     def compute_metrics(self, *args, **kwargs) -> dict[str, jax.Array]:
-        # implemented by each respective architecture
+        """
+        Compute and return a dictionary of metrics for the current batch.
+
+        This method is expected to be implemented by each subclass to compute
+        task-specific metrics using JAX arrays. It is compatible with stateless
+        execution and must be differentiable under JAX's `grad` system.
+
+        Parameters
+        ----------
+        *args : tuple
+            Positional arguments passed to the metric computation function.
+        **kwargs : dict
+            Keyword arguments passed to the metric computation function.
+
+        Returns
+        -------
+        dict of str to jax.Array
+            Dictionary containing named metric values as JAX arrays.
+        """
         raise NotImplementedError
 
     def stateless_compute_metrics(
@@ -19,17 +50,34 @@ class JAXApproximator(keras.Model):
         stage: str = "training",
     ) -> (jax.Array, tuple):
         """
-        Things we do for jax:
-        1. Accept trainable variables as the first argument
-            (can be at any position as indicated by the argnum parameter
-             in autograd, but needs to be an explicit arg)
-        2. Accept, potentially modify, and return other state variables
-        3. Return just the loss tensor as the first value
-        4. Return all other values in a tuple as the second value
+        Stateless computation of metrics required for JAX autograd.
 
-        This ensures:
-        1. The function is stateless
-        2. The function can be differentiated with jax autograd
+        This method performs a stateless forward pass using the given model
+        variables and returns both the loss and auxiliary information for
+        further updates.
+
+        Parameters
+        ----------
+        trainable_variables : Any
+            Current values of the trainable weights.
+        non_trainable_variables : Any
+            Current values of non-trainable variables (e.g., batch norm statistics).
+        metrics_variables : Any
+            Current values of metric tracking variables.
+        data : dict of str to any
+            Input data dictionary passed to `compute_metrics`.
+        stage : str, default="training"
+            Whether the computation is for "training" or "validation".
+
+        Returns
+        -------
+        loss : jax.Array
+            Scalar loss tensor for gradient computation.
+        aux : tuple
+            Tuple containing:
+                - metrics (dict of str to jax.Array)
+                - updated non-trainable variables
+                - updated metrics variables
         """
         state_mapping = []
         state_mapping.extend(zip(self.trainable_variables, trainable_variables))
@@ -48,6 +96,23 @@ class JAXApproximator(keras.Model):
         return metrics["loss"], (metrics, non_trainable_variables, metrics_variables)
 
     def stateless_test_step(self, state: tuple, data: dict[str, any]) -> (dict[str, jax.Array], tuple):
+        """
+        Stateless validation step compatible with JAX.
+
+        Parameters
+        ----------
+        state : tuple
+            Tuple of (trainable_variables, non_trainable_variables, metrics_variables).
+        data : dict of str to any
+            Input data for validation.
+
+        Returns
+        -------
+        metrics : dict of str to jax.Array
+            Dictionary of computed evaluation metrics.
+        state : tuple
+            Updated state tuple after evaluation.
+        """
         trainable_variables, non_trainable_variables, metrics_variables = state
 
         loss, aux = self.stateless_compute_metrics(
@@ -61,6 +126,25 @@ class JAXApproximator(keras.Model):
         return metrics, state
 
     def stateless_train_step(self, state: tuple, data: dict[str, any]) -> (dict[str, jax.Array], tuple):
+        """
+        Stateless training step compatible with JAX autograd and stateless optimization.
+
+        Computes gradients and applies optimizer updates in a purely functional style.
+
+        Parameters
+        ----------
+        state : tuple
+            Tuple of (trainable_variables, non_trainable_variables, optimizer_variables, metrics_variables).
+        data : dict of str to any
+            Input data for training.
+
+        Returns
+        -------
+        metrics : dict of str to jax.Array
+            Dictionary of computed training metrics.
+        state : tuple
+            Updated state tuple after training.
+        """
         trainable_variables, non_trainable_variables, optimizer_variables, metrics_variables = state
 
         grad_fn = jax.value_and_grad(self.stateless_compute_metrics, has_aux=True)
@@ -80,17 +164,61 @@ class JAXApproximator(keras.Model):
         return metrics, state
 
     def test_step(self, *args, **kwargs):
+        """
+        Alias to `stateless_test_step` for compatibility with `keras.Model`.
+
+        Parameters
+        ----------
+        *args, **kwargs : Any
+            Passed through to `stateless_test_step`.
+
+        Returns
+        -------
+        See `stateless_test_step`.
+        """
         return self.stateless_test_step(*args, **kwargs)
 
     def train_step(self, *args, **kwargs):
+        """
+        Alias to `stateless_train_step` for compatibility with `keras.Model`.
+
+        Parameters
+        ----------
+        *args, **kwargs : Any
+            Passed through to `stateless_train_step`.
+
+        Returns
+        -------
+        See `stateless_train_step`.
+        """
         return self.stateless_train_step(*args, **kwargs)
 
     def _update_metrics(self, loss: jax.Array, metrics_variables: any, sample_weight: any = None) -> any:
-        # update the loss progress bar, and possibly metrics variables along with it
+        """
+        Updates metric tracking variables in a stateless JAX-compatible way.
+
+        This method updates the loss tracker (and any other Keras metrics)
+        and returns updated metric variable states for downstream use.
+
+        Parameters
+        ----------
+        loss : jax.Array
+            Scalar loss used for metric tracking.
+        metrics_variables : Any
+            Current metric variable states.
+        sample_weight : Any, optional
+            Sample weights to apply during update.
+
+        Returns
+        -------
+        metrics_variables : Any
+            Updated metrics variable states.
+        """
         state_mapping = list(zip(self.metrics_variables, metrics_variables))
         with keras.StatelessScope(state_mapping) as scope:
             self._loss_tracker.update_state(loss, sample_weight=sample_weight)
 
+        # JAX is stateless, so we need to return the metrics as state in downstream functions
         metrics_variables = [scope.get_current_value(v) for v in self.metrics_variables]
 
         return metrics_variables

--- a/bayesflow/approximators/backend_approximators/jax_approximator.py
+++ b/bayesflow/approximators/backend_approximators/jax_approximator.py
@@ -55,7 +55,7 @@ class JAXApproximator(keras.Model):
         )
         metrics, non_trainable_variables, metrics_variables = aux
 
-        metrics_variables = self._update_loss(loss, metrics_variables)
+        metrics_variables = self._update_metrics(loss, metrics_variables)
 
         state = trainable_variables, non_trainable_variables, metrics_variables
         return metrics, state
@@ -74,7 +74,7 @@ class JAXApproximator(keras.Model):
             optimizer_variables, grads, trainable_variables
         )
 
-        metrics_variables = self._update_loss(loss, metrics_variables)
+        metrics_variables = self._update_metrics(loss, metrics_variables)
 
         state = trainable_variables, non_trainable_variables, optimizer_variables, metrics_variables
         return metrics, state
@@ -85,7 +85,7 @@ class JAXApproximator(keras.Model):
     def train_step(self, *args, **kwargs):
         return self.stateless_train_step(*args, **kwargs)
 
-    def _update_loss(self, loss: jax.Array, metrics_variables: any) -> any:
+    def _update_metrics(self, loss: jax.Array, metrics_variables: any) -> any:
         # update the loss progress bar, and possibly metrics variables along with it
         state_mapping = list(zip(self.metrics_variables, metrics_variables))
         with keras.StatelessScope(state_mapping) as scope:

--- a/bayesflow/approximators/backend_approximators/numpy_approximator.py
+++ b/bayesflow/approximators/backend_approximators/numpy_approximator.py
@@ -13,17 +13,17 @@ class NumpyApproximator(keras.Model):
     def test_step(self, data: dict[str, any]) -> dict[str, np.ndarray]:
         kwargs = filter_kwargs(data | {"stage": "validation"}, self.compute_metrics)
         metrics = self.compute_metrics(**kwargs)
-        self._update_metrics(metrics)
+        self._update_metrics(metrics, self._batch_size_from_data(data))
         return metrics
 
     def train_step(self, data: dict[str, any]) -> dict[str, np.ndarray]:
         raise NotImplementedError("Numpy backend does not support training.")
 
-    def _update_metrics(self, metrics):
+    def _update_metrics(self, metrics, sample_weight=None):
         for name, value in metrics.items():
             try:
                 metric_index = self.metrics_names.index(name)
-                self.metrics[metric_index].update_state(value)
+                self.metrics[metric_index].update_state(value, sample_weight=sample_weight)
             except ValueError:
                 self._metrics.append(keras.metrics.Mean(name=name))
-                self._metrics[-1].update_state(value)
+                self._metrics[-1].update_state(value, sample_weight=sample_weight)

--- a/bayesflow/approximators/backend_approximators/numpy_approximator.py
+++ b/bayesflow/approximators/backend_approximators/numpy_approximator.py
@@ -27,3 +27,12 @@ class NumpyApproximator(keras.Model):
             except ValueError:
                 self._metrics.append(keras.metrics.Mean(name=name))
                 self._metrics[-1].update_state(value, sample_weight=sample_weight)
+
+    # noinspection PyMethodOverriding
+    def _batch_size_from_data(self, data: any) -> int:
+        raise NotImplementedError(
+            "Correct calculation of the metrics requires obtaining the batch size from the supplied data "
+            "for proper weighting of metrics for batches with different sizes. Please implement the "
+            "_batch_size_from_data method for your approximator. For a given batch of data, it should "
+            "return the corresponding batch size."
+        )

--- a/bayesflow/approximators/backend_approximators/tensorflow_approximator.py
+++ b/bayesflow/approximators/backend_approximators/tensorflow_approximator.py
@@ -12,7 +12,10 @@ class TensorFlowApproximator(keras.Model):
 
     def test_step(self, data: dict[str, any]) -> dict[str, tf.Tensor]:
         kwargs = filter_kwargs(data | {"stage": "validation"}, self.compute_metrics)
-        return self.compute_metrics(**kwargs)
+        metrics = self.compute_metrics(**kwargs)
+        loss = metrics["loss"]
+        self._loss_tracker.update_state(loss)
+        return metrics
 
     def train_step(self, data: dict[str, any]) -> dict[str, tf.Tensor]:
         with tf.GradientTape() as tape:

--- a/bayesflow/approximators/backend_approximators/tensorflow_approximator.py
+++ b/bayesflow/approximators/backend_approximators/tensorflow_approximator.py
@@ -5,18 +5,83 @@ from bayesflow.utils import filter_kwargs
 
 
 class TensorFlowApproximator(keras.Model):
+    """
+    Base class for approximators using TensorFlow and Keras training logic.
+
+    This class supports training and evaluation loops using TensorFlow backends.
+    Subclasses are responsible for implementing the `compute_metrics` method and
+    `_batch_size_from_data`, which extracts batch size information from data inputs.
+
+    Notes
+    -----
+    Subclasses must implement:
+        - compute_metrics(self, *args, **kwargs) -> dict[str, tf.Tensor]
+        - _batch_size_from_data(self, data: dict[str, any]) -> int
+    """
+
     # noinspection PyMethodOverriding
     def compute_metrics(self, *args, **kwargs) -> dict[str, tf.Tensor]:
-        # implemented by each respective architecture
+        """
+        Compute and return a dictionary of metrics for the current batch.
+
+        This method is expected to be implemented by each subclass to compute task-specific
+        metrics (e.g., loss, accuracy). The arguments are dynamically filtered based on the
+        architecture's metric signature.
+
+        Parameters
+        ----------
+        *args : tuple
+            Positional arguments passed to the metric computation function.
+        **kwargs : dict
+            Keyword arguments passed to the metric computation function.
+
+        Returns
+        -------
+        dict of str to tf.Tensor
+            Dictionary containing named metric values as TensorFlow tensors.
+        """
         raise NotImplementedError
 
     def test_step(self, data: dict[str, any]) -> dict[str, tf.Tensor]:
+        """
+        Performs a single validation step.
+
+        Filters relevant keyword arguments for metric computation and updates internal
+        metric trackers using the validation data.
+
+        Parameters
+        ----------
+        data : dict of str to any
+            Input dictionary containing model inputs and possibly additional information
+            such as sample_weight or mask.
+
+        Returns
+        -------
+        dict of str to tf.Tensor
+            Dictionary of computed validation metrics.
+        """
         kwargs = filter_kwargs(data | {"stage": "validation"}, self.compute_metrics)
         metrics = self.compute_metrics(**kwargs)
         self._update_metrics(metrics, self._batch_size_from_data(data))
         return metrics
 
     def train_step(self, data: dict[str, any]) -> dict[str, tf.Tensor]:
+        """
+        Performs a single training step with gradient update.
+
+        Computes gradients of the loss with respect to the trainable variables, applies
+        the update, and updates internal metric trackers.
+
+        Parameters
+        ----------
+        data : dict of str to any
+            Input dictionary containing model inputs and training targets.
+
+        Returns
+        -------
+        dict of str to tf.Tensor
+            Dictionary of computed training metrics.
+        """
         with tf.GradientTape() as tape:
             kwargs = filter_kwargs(data | {"stage": "training"}, self.compute_metrics)
             metrics = self.compute_metrics(**kwargs)
@@ -29,7 +94,19 @@ class TensorFlowApproximator(keras.Model):
         self._update_metrics(metrics, self._batch_size_from_data(data))
         return metrics
 
-    def _update_metrics(self, metrics, sample_weight=None):
+    def _update_metrics(self, metrics: dict[str, any], sample_weight: tf.Tensor = None):
+        """
+        Updates internal Keras metric objects with the given values.
+
+        If a new metric name is encountered, it is added as a new `keras.metrics.Mean` instance.
+
+        Parameters
+        ----------
+        metrics : dict of str to any
+            Dictionary of computed metric values to update.
+        sample_weight : tf.Tensor, optional
+            Sample weights to apply during metric update.
+        """
         for name, value in metrics.items():
             try:
                 metric_index = self.metrics_names.index(name)

--- a/bayesflow/approximators/backend_approximators/tensorflow_approximator.py
+++ b/bayesflow/approximators/backend_approximators/tensorflow_approximator.py
@@ -13,8 +13,7 @@ class TensorFlowApproximator(keras.Model):
     def test_step(self, data: dict[str, any]) -> dict[str, tf.Tensor]:
         kwargs = filter_kwargs(data | {"stage": "validation"}, self.compute_metrics)
         metrics = self.compute_metrics(**kwargs)
-        loss = metrics["loss"]
-        self._loss_tracker.update_state(loss)
+        self._update_metrics(metrics)
         return metrics
 
     def train_step(self, data: dict[str, any]) -> dict[str, tf.Tensor]:
@@ -27,6 +26,14 @@ class TensorFlowApproximator(keras.Model):
         grads = tape.gradient(loss, self.trainable_variables)
         self.optimizer.apply_gradients(zip(grads, self.trainable_variables))
 
-        self._loss_tracker.update_state(loss)
-
+        self._update_metrics(metrics)
         return metrics
+
+    def _update_metrics(self, metrics):
+        for name, value in metrics.items():
+            try:
+                metric_index = self.metrics_names.index(name)
+                self.metrics[metric_index].update_state(value)
+            except ValueError:
+                self._metrics.append(keras.metrics.Mean(name=name))
+                self._metrics[-1].update_state(value)

--- a/bayesflow/approximators/backend_approximators/tensorflow_approximator.py
+++ b/bayesflow/approximators/backend_approximators/tensorflow_approximator.py
@@ -32,7 +32,7 @@ class TensorFlowApproximator(keras.Model):
         ----------
         *args : tuple
             Positional arguments passed to the metric computation function.
-        **kwargs : dict
+        **kwargs
             Keyword arguments passed to the metric computation function.
 
         Returns
@@ -114,3 +114,28 @@ class TensorFlowApproximator(keras.Model):
             except ValueError:
                 self._metrics.append(keras.metrics.Mean(name=name))
                 self._metrics[-1].update_state(value, sample_weight=sample_weight)
+
+    # noinspection PyMethodOverriding
+    def _batch_size_from_data(self, data: any) -> int:
+        """Obtain the batch size from a batch of data.
+
+        To properly weigh the metrics for batches of different sizes, the batch size of a given batch of data is
+        required. As the data structure differs between approximators, each concrete approximator has to specify
+        this method.
+
+        Parameters
+        ----------
+        data :
+            The data that are passed to `compute_metrics` as keyword arguments.
+
+        Returns
+        -------
+        batch_size : int
+            The batch size of the given data.
+        """
+        raise NotImplementedError(
+            "Correct calculation of the metrics requires obtaining the batch size from the supplied data "
+            "for proper weighting of metrics for batches with different sizes. Please implement the "
+            "_batch_size_from_data method for your approximator. For a given batch of data, it should "
+            "return the corresponding batch size."
+        )

--- a/bayesflow/approximators/backend_approximators/torch_approximator.py
+++ b/bayesflow/approximators/backend_approximators/torch_approximator.py
@@ -33,7 +33,7 @@ class TorchApproximator(keras.Model):
         ----------
         *args : tuple
             Positional arguments passed to the metric computation function.
-        **kwargs : dict
+        **kwargs
             Keyword arguments passed to the metric computation function.
 
         Returns
@@ -124,3 +124,28 @@ class TorchApproximator(keras.Model):
             except ValueError:
                 self._metrics.append(keras.metrics.Mean(name=name))
                 self._metrics[-1].update_state(value, sample_weight=sample_weight)
+
+    # noinspection PyMethodOverriding
+    def _batch_size_from_data(self, data: any) -> int:
+        """Obtain the batch size from a batch of data.
+
+        To properly weigh the metrics for batches of different sizes, the batch size of a given batch of data is
+        required. As the data structure differs between approximators, each concrete approximator has to specify
+        this method.
+
+        Parameters
+        ----------
+        data :
+            The data that are passed to `compute_metrics` as keyword arguments.
+
+        Returns
+        -------
+        batch_size : int
+            The batch size of the given data.
+        """
+        raise NotImplementedError(
+            "Correct calculation of the metrics requires obtaining the batch size from the supplied data "
+            "for proper weighting of metrics for batches with different sizes. Please implement the "
+            "_batch_size_from_data method for your approximator. For a given batch of data, it should "
+            "return the corresponding batch size."
+        )

--- a/bayesflow/approximators/backend_approximators/torch_approximator.py
+++ b/bayesflow/approximators/backend_approximators/torch_approximator.py
@@ -12,7 +12,10 @@ class TorchApproximator(keras.Model):
 
     def test_step(self, data: dict[str, any]) -> dict[str, torch.Tensor]:
         kwargs = filter_kwargs(data | {"stage": "validation"}, self.compute_metrics)
-        return self.compute_metrics(**kwargs)
+        metrics = self.compute_metrics(**kwargs)
+        loss = metrics["loss"]
+        self._loss_tracker.update_state(loss)
+        return metrics
 
     def train_step(self, data: dict[str, any]) -> dict[str, torch.Tensor]:
         with torch.enable_grad():

--- a/bayesflow/approximators/backend_approximators/torch_approximator.py
+++ b/bayesflow/approximators/backend_approximators/torch_approximator.py
@@ -13,7 +13,7 @@ class TorchApproximator(keras.Model):
     def test_step(self, data: dict[str, any]) -> dict[str, torch.Tensor]:
         kwargs = filter_kwargs(data | {"stage": "validation"}, self.compute_metrics)
         metrics = self.compute_metrics(**kwargs)
-        self._update_metrics(metrics)
+        self._update_metrics(metrics, self._batch_size_from_data(data))
         return metrics
 
     def train_step(self, data: dict[str, any]) -> dict[str, torch.Tensor]:
@@ -34,14 +34,14 @@ class TorchApproximator(keras.Model):
         with torch.no_grad():
             self.optimizer.apply(gradients, trainable_weights)
 
-        self._update_metrics(metrics)
+        self._update_metrics(metrics, self._batch_size_from_data(data))
         return metrics
 
-    def _update_metrics(self, metrics):
+    def _update_metrics(self, metrics, sample_weight=None):
         for name, value in metrics.items():
             try:
                 metric_index = self.metrics_names.index(name)
-                self.metrics[metric_index].update_state(value)
+                self.metrics[metric_index].update_state(value, sample_weight=sample_weight)
             except ValueError:
                 self._metrics.append(keras.metrics.Mean(name=name))
-                self._metrics[-1].update_state(value)
+                self._metrics[-1].update_state(value, sample_weight=sample_weight)

--- a/bayesflow/approximators/backend_approximators/torch_approximator.py
+++ b/bayesflow/approximators/backend_approximators/torch_approximator.py
@@ -5,18 +5,84 @@ from bayesflow.utils import filter_kwargs
 
 
 class TorchApproximator(keras.Model):
+    """
+    Base class for approximators using PyTorch and Keras-compatible training loops.
+
+    This class defines a generic structure for metric computation, training, and evaluation
+    using PyTorch backends. Subclasses must implement the `compute_metrics` method to return
+    task-specific metrics, and the `_batch_size_from_data` method to extract batch size
+    from the input data dictionary.
+
+    Notes
+    -----
+    Subclasses must implement:
+        - compute_metrics(self, *args, **kwargs) -> dict[str, torch.Tensor]
+        - _batch_size_from_data(self, data: dict[str, any]) -> int
+    """
+
     # noinspection PyMethodOverriding
     def compute_metrics(self, *args, **kwargs) -> dict[str, torch.Tensor]:
-        # implemented by each respective architecture
+        """
+        Compute and return a dictionary of metrics for the current batch.
+
+        This method must be implemented by subclasses to compute relevant metrics
+        (e.g., loss, accuracy) using PyTorch tensors. Inputs are dynamically filtered
+        based on the metric function signature.
+
+        Parameters
+        ----------
+        *args : tuple
+            Positional arguments passed to the metric computation function.
+        **kwargs : dict
+            Keyword arguments passed to the metric computation function.
+
+        Returns
+        -------
+        dict of str to torch.Tensor
+            Dictionary of metric names and their corresponding torch tensors.
+        """
         raise NotImplementedError
 
     def test_step(self, data: dict[str, any]) -> dict[str, torch.Tensor]:
+        """
+        Performs a single validation step.
+
+        Filters relevant keyword arguments for metric computation and updates internal
+        metric trackers using the validation data.
+
+        Parameters
+        ----------
+        data : dict of str to any
+            Input dictionary containing model inputs and possibly additional information
+            such as sample_weight or mask.
+
+        Returns
+        -------
+        dict of str to tf.Tensor
+            Dictionary of computed validation metrics.
+        """
         kwargs = filter_kwargs(data | {"stage": "validation"}, self.compute_metrics)
         metrics = self.compute_metrics(**kwargs)
         self._update_metrics(metrics, self._batch_size_from_data(data))
         return metrics
 
     def train_step(self, data: dict[str, any]) -> dict[str, torch.Tensor]:
+        """
+        Performs a single training step with gradient update.
+
+        Computes gradients of the loss with respect to the trainable variables, applies
+        the update, and updates internal metric trackers.
+
+        Parameters
+        ----------
+        data : dict of str to any
+            Input dictionary containing model inputs and training targets.
+
+        Returns
+        -------
+        dict of str to tf.Tensor
+            Dictionary of computed training metrics.
+        """
         with torch.enable_grad():
             kwargs = filter_kwargs(data | {"stage": "training"}, self.compute_metrics)
             metrics = self.compute_metrics(**kwargs)
@@ -37,7 +103,20 @@ class TorchApproximator(keras.Model):
         self._update_metrics(metrics, self._batch_size_from_data(data))
         return metrics
 
-    def _update_metrics(self, metrics, sample_weight=None):
+    def _update_metrics(self, metrics: dict[str, any], sample_weight: torch.Tensor = None):
+        """
+        Updates internal Keras metric trackers using provided metric values.
+
+        Adds new metrics to the tracker list as `keras.metrics.Mean` instances if
+        not already present.
+
+        Parameters
+        ----------
+        metrics : dict of str to any
+            Dictionary of computed metrics for the current batch.
+        sample_weight : torch.Tensor, optional
+            Sample weights used during metric updates.
+        """
         for name, value in metrics.items():
             try:
                 metric_index = self.metrics_names.index(name)

--- a/bayesflow/approximators/continuous_approximator.py
+++ b/bayesflow/approximators/continuous_approximator.py
@@ -492,5 +492,9 @@ class ContinuousApproximator(Approximator):
             **filter_kwargs(kwargs, self.inference_network.log_prob),
         )
 
-    def _batch_size_from_data(self, data: Mapping[str, any]):
+    def _batch_size_from_data(self, data: Mapping[str, any]) -> int:
+        """
+        Fetches the current batch size from an input dictionary. Can only be used during training when
+        inference variables as present.
+        """
         return keras.ops.shape(data["inference_variables"])[0]

--- a/bayesflow/approximators/continuous_approximator.py
+++ b/bayesflow/approximators/continuous_approximator.py
@@ -150,14 +150,9 @@ class ContinuousApproximator(Approximator):
             inference_variables, conditions=inference_conditions, sample_weight=sample_weight, stage=stage
         )
 
-        loss = inference_metrics.get("loss", keras.ops.zeros(())) + summary_metrics.get("loss", keras.ops.zeros(()))
+        loss = inference_metrics["loss"] + summary_metrics.get("loss", keras.ops.zeros(()))
 
-        inference_metrics = {f"{key}/inference_{key}": value for key, value in inference_metrics.items()}
-        summary_metrics = {f"{key}/summary_{key}": value for key, value in summary_metrics.items()}
-
-        metrics = {"loss": loss} | inference_metrics | summary_metrics
-
-        return metrics
+        return {"loss": loss}
 
     def fit(self, *args, **kwargs):
         """

--- a/bayesflow/approximators/continuous_approximator.py
+++ b/bayesflow/approximators/continuous_approximator.py
@@ -491,3 +491,6 @@ class ContinuousApproximator(Approximator):
             conditions=inference_conditions,
             **filter_kwargs(kwargs, self.inference_network.log_prob),
         )
+
+    def _batch_size_from_data(self, data: Mapping[str, any]):
+        return keras.ops.shape(data["inference_variables"])[0]

--- a/bayesflow/approximators/continuous_approximator.py
+++ b/bayesflow/approximators/continuous_approximator.py
@@ -150,9 +150,15 @@ class ContinuousApproximator(Approximator):
             inference_variables, conditions=inference_conditions, sample_weight=sample_weight, stage=stage
         )
 
-        loss = inference_metrics["loss"] + summary_metrics.get("loss", keras.ops.zeros(()))
+        if "loss" in summary_metrics:
+            loss = inference_metrics["loss"] + summary_metrics["loss"]
+        else:
+            loss = inference_metrics.pop("loss")
+        inference_metrics = {f"{key}/inference_{key}": value for key, value in inference_metrics.items()}
+        summary_metrics = {f"{key}/summary_{key}": value for key, value in summary_metrics.items()}
 
-        return {"loss": loss}
+        metrics = {"loss": loss} | inference_metrics | summary_metrics
+        return metrics
 
     def fit(self, *args, **kwargs):
         """

--- a/bayesflow/approximators/model_comparison_approximator.py
+++ b/bayesflow/approximators/model_comparison_approximator.py
@@ -379,5 +379,9 @@ class ModelComparisonApproximator(Approximator):
         summaries = self.summary_network(summary_variables, **filter_kwargs(kwargs, self.summary_network.call))
         return summaries
 
-    def _batch_size_from_data(self, data: Mapping[str, any]):
+    def _batch_size_from_data(self, data: Mapping[str, any]) -> int:
+        """
+        Fetches the current batch size from an input dictionary. Can only be used during training when
+        model indices as present.
+        """
         return keras.ops.shape(data["model_indices"])[0]

--- a/bayesflow/approximators/model_comparison_approximator.py
+++ b/bayesflow/approximators/model_comparison_approximator.py
@@ -378,3 +378,6 @@ class ModelComparisonApproximator(Approximator):
         summary_variables = keras.ops.convert_to_tensor(data_adapted["summary_variables"])
         summaries = self.summary_network(summary_variables, **filter_kwargs(kwargs, self.summary_network.call))
         return summaries
+
+    def _batch_size_from_data(self, data: Mapping[str, any]):
+        return keras.ops.shape(data["model_indices"])[0]

--- a/tests/test_two_moons/test_two_moons.py
+++ b/tests/test_two_moons/test_two_moons.py
@@ -13,9 +13,12 @@ def test_compile(approximator, random_samples, jit_compile):
 
 
 def test_fit(approximator, train_dataset, validation_dataset, batch_size):
+    from bayesflow.metrics import MaximumMeanDiscrepancy
+    from bayesflow.networks import PointInferenceNetwork
+
     inference_metrics = []
-    # if not isinstance(approximator.inference_network, PointInferenceNetwork):
-    #     inference_metrics += [MaximumMeanDiscrepancy()]
+    if not isinstance(approximator.inference_network, PointInferenceNetwork):
+        inference_metrics += [MaximumMeanDiscrepancy()]
     approximator.compile(inference_metrics=inference_metrics)
 
     mock_data = train_dataset[0]
@@ -38,8 +41,8 @@ def test_fit(approximator, train_dataset, validation_dataset, batch_size):
 
     # test that metrics are improving
     metric_names = ["loss"]
-    # if not isinstance(approximator.inference_network, PointInferenceNetwork):
-    #     metric_names += ["maximum_mean_discrepancy/inference_maximum_mean_discrepancy"]
+    if not isinstance(approximator.inference_network, PointInferenceNetwork):
+        metric_names += ["maximum_mean_discrepancy/inference_maximum_mean_discrepancy"]
     for metric in metric_names:
         assert metric in untrained_metrics
         assert metric in trained_metrics

--- a/tests/test_two_moons/test_two_moons.py
+++ b/tests/test_two_moons/test_two_moons.py
@@ -13,12 +13,9 @@ def test_compile(approximator, random_samples, jit_compile):
 
 
 def test_fit(approximator, train_dataset, validation_dataset, batch_size):
-    from bayesflow.metrics import MaximumMeanDiscrepancy
-    from bayesflow.networks import PointInferenceNetwork
-
     inference_metrics = []
-    if not isinstance(approximator.inference_network, PointInferenceNetwork):
-        inference_metrics += [MaximumMeanDiscrepancy()]
+    # if not isinstance(approximator.inference_network, PointInferenceNetwork):
+    #     inference_metrics += [MaximumMeanDiscrepancy()]
     approximator.compile(inference_metrics=inference_metrics)
 
     mock_data = train_dataset[0]
@@ -41,8 +38,8 @@ def test_fit(approximator, train_dataset, validation_dataset, batch_size):
 
     # test that metrics are improving
     metric_names = ["loss"]
-    if not isinstance(approximator.inference_network, PointInferenceNetwork):
-        metric_names += ["maximum_mean_discrepancy/inference_maximum_mean_discrepancy"]
+    # if not isinstance(approximator.inference_network, PointInferenceNetwork):
+    #     metric_names += ["maximum_mean_discrepancy/inference_maximum_mean_discrepancy"]
     for metric in metric_names:
         assert metric in untrained_metrics
         assert metric in trained_metrics


### PR DESCRIPTION
This PR:

- Fixes #481 
- Supercedes #483 
- Fixes validation loss tracking in `test_step`
- Removes `loss/..._loss` and other nested metrics
- Temporarily removes the ability to track custom metrics

Future TODO:
- We have to reenable tracking custom metrics by keeping a `keras.metrics.Mean` tracker object on the approximator for each custom metric the user passes. We also need to call `update_state` on each of those trackers in the `compute_metrics` or `train/test_step` method.

@vpratz Do you think you have capacity to take care of the TODO?