### PR TITLE
Add Nnpe adapter class

### DIFF
--- a/bayesflow/adapters/adapter.py
+++ b/bayesflow/adapters/adapter.py
@@ -704,8 +704,8 @@ class Adapter(MutableSequence[Transform]):
         self,
         keys: str | Sequence[str],
         *,
-        slab_scale: float = 0.25,
-        spike_scale: float = 0.01,
+        spike_scale: float | None = None,
+        slab_scale: float | None = None,
         seed: int | None = None,
     ):
         """Append an :py:class:`~transforms.NNPE` transform to the adapter.
@@ -714,17 +714,17 @@ class Adapter(MutableSequence[Transform]):
         ----------
         keys : str or Sequence of str
             The names of the variables to transform.
-        slab_scale : float
-            The scale of the slab (Cauchy) distribution.
-        spike_scale : float
-            The scale of the spike spike (Normal) distribution.
+        spike_scale : float or None
+            The scale of the spike (Normal) distribution. Automatically determined if None.
+        slab_scale : float or None
+            The scale of the slab (Cauchy) distribution. Automatically determined if None.
         seed : int or None
             The seed for the random number generator. If None, a random seed is used.
         """
         if isinstance(keys, str):
             keys = [keys]
 
-        transform = MapTransform({key: NNPE(slab_scale=slab_scale, spike_scale=spike_scale, seed=seed) for key in keys})
+        transform = MapTransform({key: NNPE(spike_scale=spike_scale, slab_scale=slab_scale, seed=seed) for key in keys})
         self.transforms.append(transform)
         return self
 

--- a/bayesflow/adapters/adapter.py
+++ b/bayesflow/adapters/adapter.py
@@ -706,6 +706,7 @@ class Adapter(MutableSequence[Transform]):
         *,
         spike_scale: float | None = None,
         slab_scale: float | None = None,
+        per_dimension: bool = True,
         seed: int | None = None,
     ):
         """Append an :py:class:`~transforms.NNPE` transform to the adapter.
@@ -714,17 +715,25 @@ class Adapter(MutableSequence[Transform]):
         ----------
         keys : str or Sequence of str
             The names of the variables to transform.
-        spike_scale : float or None
+        spike_scale : float or np.ndarray or None, default=None
             The scale of the spike (Normal) distribution. Automatically determined if None.
-        slab_scale : float or None
+        slab_scale : float or np.ndarray or None, default=None
             The scale of the slab (Cauchy) distribution. Automatically determined if None.
+        per_dimension : bool, default=True
+            If true, noise is applied per dimension of the last axis of the input data.
+            If false, noise is applied globally.
         seed : int or None
             The seed for the random number generator. If None, a random seed is used.
         """
         if isinstance(keys, str):
             keys = [keys]
 
-        transform = MapTransform({key: NNPE(spike_scale=spike_scale, slab_scale=slab_scale, seed=seed) for key in keys})
+        transform = MapTransform(
+            {
+                key: NNPE(spike_scale=spike_scale, slab_scale=slab_scale, per_dimension=per_dimension, seed=seed)
+                for key in keys
+            }
+        )
         self.transforms.append(transform)
         return self
 

--- a/bayesflow/adapters/adapter.py
+++ b/bayesflow/adapters/adapter.py
@@ -18,7 +18,7 @@ from .transforms import (
     Keep,
     Log,
     MapTransform,
-    Nnpe,
+    NNPE,
     NumpyTransform,
     OneHot,
     Rename,
@@ -708,7 +708,7 @@ class Adapter(MutableSequence[Transform]):
         spike_scale: float = 0.01,
         seed: int | None = None,
     ):
-        """Append an :py:class:`~transforms.Nnpe` transform to the adapter.
+        """Append an :py:class:`~transforms.NNPE` transform to the adapter.
 
         Parameters
         ----------
@@ -724,7 +724,7 @@ class Adapter(MutableSequence[Transform]):
         if isinstance(keys, str):
             keys = [keys]
 
-        transform = MapTransform({key: Nnpe(slab_scale=slab_scale, spike_scale=spike_scale, seed=seed) for key in keys})
+        transform = MapTransform({key: NNPE(slab_scale=slab_scale, spike_scale=spike_scale, seed=seed) for key in keys})
         self.transforms.append(transform)
         return self
 

--- a/bayesflow/adapters/adapter.py
+++ b/bayesflow/adapters/adapter.py
@@ -18,6 +18,7 @@ from .transforms import (
     Keep,
     Log,
     MapTransform,
+    Nnpe,
     NumpyTransform,
     OneHot,
     Rename,
@@ -696,6 +697,34 @@ class Adapter(MutableSequence[Transform]):
             keys = [keys]
 
         transform = MapTransform({key: ConvertDType(to_dtype) for key in keys})
+        self.transforms.append(transform)
+        return self
+
+    def nnpe(
+        self,
+        keys: str | Sequence[str],
+        *,
+        slab_scale: float = 0.25,
+        spike_scale: float = 0.01,
+        seed: int | None = None,
+    ):
+        """Append an :py:class:`~transforms.Nnpe` transform to the adapter.
+
+        Parameters
+        ----------
+        keys : str or Sequence of str
+            The names of the variables to transform.
+        slab_scale : float
+            The scale of the slab (Cauchy) distribution.
+        spike_scale : float
+            The scale of the spike spike (Normal) distribution.
+        seed : int or None
+            The seed for the random number generator. If None, a random seed is used.
+        """
+        if isinstance(keys, str):
+            keys = [keys]
+
+        transform = MapTransform({key: Nnpe(slab_scale=slab_scale, spike_scale=spike_scale, seed=seed) for key in keys})
         self.transforms.append(transform)
         return self
 

--- a/bayesflow/adapters/transforms/__init__.py
+++ b/bayesflow/adapters/transforms/__init__.py
@@ -12,6 +12,7 @@ from .group import Group
 from .keep import Keep
 from .log import Log
 from .map_transform import MapTransform
+from .nnpe import Nnpe
 from .numpy_transform import NumpyTransform
 from .one_hot import OneHot
 from .rename import Rename

--- a/bayesflow/adapters/transforms/__init__.py
+++ b/bayesflow/adapters/transforms/__init__.py
@@ -12,7 +12,7 @@ from .group import Group
 from .keep import Keep
 from .log import Log
 from .map_transform import MapTransform
-from .nnpe import Nnpe
+from .nnpe import NNPE
 from .numpy_transform import NumpyTransform
 from .one_hot import OneHot
 from .rename import Rename

--- a/bayesflow/adapters/transforms/nnpe.py
+++ b/bayesflow/adapters/transforms/nnpe.py
@@ -1,0 +1,61 @@
+import numpy as np
+
+from bayesflow.utils.serialization import serializable, serialize
+
+from .elementwise_transform import ElementwiseTransform
+
+
+@serializable("bayesflow.adapters")
+class Nnpe(ElementwiseTransform):
+    """Implements noisy neural posterior estimation (NNPE) as described in [1], which adds noise following a
+    spike-and-slab distribution to the training data as a mild form of data augmentation to robustify against noisy
+    real-world data (see [1, 2] for benchmarks).
+
+    [1] Ward, D., Cannon, P., Beaumont, M., Fasiolo, M., & Schmon, S. (2022). Robust neural posterior estimation and
+    statistical model criticism. Advances in Neural Information Processing Systems, 35, 33845-33859.
+    [2] Elsemüller, L., Pratz, V., von Krause, M., Voss, A., Bürkner, P. C., & Radev, S. T. (2025). Does Unsupervised
+    Domain Adaptation Improve the Robustness of Amortized Bayesian Inference? A Systematic Evaluation. arXiv preprint
+    arXiv:2502.04949.
+
+    Parameters
+    ----------
+    slab_scale : float
+        The scale of the slab (Cauchy) distribution.
+    spike_scale : float
+        The scale of the spike spike (Normal) distribution.
+    seed : int or None
+        The seed for the random number generator. If None, a random seed is used. Used instead of np.random.Generator
+        here to enable easy serialization.
+
+    Notes
+    -----
+    The spike-and-slab distribution consists of a mixture of a Cauchy (slab) and a Normal distribution (spike), which
+    are applied based on a Bernoulli random variable with p=0.5.
+
+    The default scales follow [1] and expect standardized data (e.g., via the `Standardize` adapter). It is therefore
+    recommended to adapt the scales when using unstandardized training data.
+
+    Examples
+    --------
+    >>> adapter = bf.Adapter().nnpe(["x"])
+    """
+
+    def __init__(self, *, slab_scale: float = 0.25, spike_scale: float = 0.01, seed: int = None):
+        super().__init__()
+        self.slab_scale = slab_scale
+        self.spike_scale = spike_scale
+        self.seed = seed
+        self.rng = np.random.default_rng(seed)
+
+    def forward(self, data: np.ndarray, **kwargs) -> np.ndarray:
+        mixture_mask = self.rng.binomial(n=1, p=0.5, size=data.shape).astype(bool)
+        noise_slab = self.rng.standard_cauchy(size=data.shape) * self.slab_scale
+        noise_spike = self.rng.standard_normal(size=data.shape) * self.spike_scale
+        noise = np.where(mixture_mask, noise_slab, noise_spike)
+        return data + noise
+
+    def inverse(self, data: np.ndarray, **kwargs) -> np.ndarray:
+        return np.exp(data)
+
+    def get_config(self) -> dict:
+        return serialize({"slab_scale": self.slab_scale, "spike_scale": self.spike_scale, "seed": self.seed})

--- a/bayesflow/adapters/transforms/nnpe.py
+++ b/bayesflow/adapters/transforms/nnpe.py
@@ -6,7 +6,7 @@ from .elementwise_transform import ElementwiseTransform
 
 
 @serializable("bayesflow.adapters")
-class Nnpe(ElementwiseTransform):
+class NNPE(ElementwiseTransform):
     """Implements noisy neural posterior estimation (NNPE) as described in [1], which adds noise following a
     spike-and-slab distribution to the training data as a mild form of data augmentation to robustify against noisy
     real-world data (see [1, 2] for benchmarks).
@@ -48,6 +48,23 @@ class Nnpe(ElementwiseTransform):
         self.rng = np.random.default_rng(seed)
 
     def forward(self, data: np.ndarray, stage: str = "inference", **kwargs) -> np.ndarray:
+        """
+        Add spike‐and‐slab noise (see “Notes” section of the class docstring for details) to `data` during training.
+
+        Parameters
+        ----------
+        data : np.ndarray
+            Input array to be perturbed.
+        stage : str, default='inference'
+            If 'training', noise is added; else data is returned unchanged.
+        **kwargs
+            Unused keyword arguments.
+
+        Returns
+        -------
+        np.ndarray
+            Noisy data when `stage` is 'training', otherwise the original input.
+        """
         if stage != "training":
             return data
         mixture_mask = self.rng.binomial(n=1, p=0.5, size=data.shape).astype(bool)
@@ -57,6 +74,7 @@ class Nnpe(ElementwiseTransform):
         return data + noise
 
     def inverse(self, data: np.ndarray, **kwargs) -> np.ndarray:
+        """Non-invertible transform."""
         return data
 
     def get_config(self) -> dict:

--- a/bayesflow/adapters/transforms/nnpe.py
+++ b/bayesflow/adapters/transforms/nnpe.py
@@ -47,7 +47,9 @@ class Nnpe(ElementwiseTransform):
         self.seed = seed
         self.rng = np.random.default_rng(seed)
 
-    def forward(self, data: np.ndarray, **kwargs) -> np.ndarray:
+    def forward(self, data: np.ndarray, stage: str = "inference", **kwargs) -> np.ndarray:
+        if stage != "training":
+            return data
         mixture_mask = self.rng.binomial(n=1, p=0.5, size=data.shape).astype(bool)
         noise_slab = self.rng.standard_cauchy(size=data.shape) * self.slab_scale
         noise_spike = self.rng.standard_normal(size=data.shape) * self.spike_scale

--- a/bayesflow/adapters/transforms/nnpe.py
+++ b/bayesflow/adapters/transforms/nnpe.py
@@ -57,7 +57,7 @@ class Nnpe(ElementwiseTransform):
         return data + noise
 
     def inverse(self, data: np.ndarray, **kwargs) -> np.ndarray:
-        return np.exp(data)
+        return data
 
     def get_config(self) -> dict:
         return serialize({"slab_scale": self.slab_scale, "spike_scale": self.spike_scale, "seed": self.seed})

--- a/bayesflow/adapters/transforms/nnpe.py
+++ b/bayesflow/adapters/transforms/nnpe.py
@@ -130,8 +130,10 @@ class NNPE(ElementwiseTransform):
             else:
                 try:
                     scalar = float(passed)
-                except Exception:
-                    raise TypeError(f"{name}: expected scalar float, got {type(passed).__name__}")
+                except TypeError:
+                    raise TypeError(f"{name}: expected a scalar convertible to float, got type {type(passed).__name__}")
+                except ValueError:
+                    raise ValueError(f"{name}: expected a scalar convertible to float, got value {passed!r}")
                 return scalar
 
     def forward(self, data: np.ndarray, stage: str = "inference", **kwargs) -> np.ndarray:

--- a/tests/test_adapters/test_adapters.py
+++ b/tests/test_adapters/test_adapters.py
@@ -308,6 +308,7 @@ def test_nnpe(random_data):
     result_training = ad(random_data, stage="training")
     result_validation = ad(random_data, stage="validation")
     result_inference = ad(random_data, stage="inference")
+    result_inversed = ad(random_data, inverse=True)
     serialized = serialize(ad)
     deserialized = deserialize(serialized)
     reserialized = serialize(deserialized)
@@ -324,7 +325,8 @@ def test_nnpe(random_data):
             continue
         assert np.allclose(result_training[k], v)
 
-    # check that the validation and inference data is unchanged
+    # check that the validation and inference data as well as inversed results are unchanged
     for k, v in random_data.items():
         assert np.allclose(result_validation[k], v)
         assert np.allclose(result_inference[k], v)
+        assert np.allclose(result_inversed[k], v)

--- a/tests/test_adapters/test_adapters.py
+++ b/tests/test_adapters/test_adapters.py
@@ -304,7 +304,8 @@ def test_nnpe(random_data):
     import numpy as np
     from bayesflow.adapters import Adapter
 
-    ad = Adapter().nnpe("x1", spike_scale=1.0, slab_scale=1.0, seed=42)
+    # Test basic case with global noise application
+    ad = Adapter().nnpe("x1", spike_scale=1.0, slab_scale=1.0, per_dimension=False, seed=42)
     result_training = ad(random_data, stage="training")
     result_validation = ad(random_data, stage="validation")
     result_inference = ad(random_data, stage="inference")
@@ -331,13 +332,8 @@ def test_nnpe(random_data):
         assert np.allclose(result_inference[k], v)
         assert np.allclose(result_inversed[k], v)
 
-    # Test at least one scale is None case (automatic scale determination)
-    ad_partial = Adapter().nnpe("x2", slab_scale=None, spike_scale=1.0, seed=42)
-    result_training_partial = ad_partial(random_data, stage="training")
-    assert not np.allclose(result_training_partial["x2"], random_data["x2"])
-
-    # Test both scales and seed are None case (automatic scale determination)
-    ad_auto = Adapter().nnpe("y1", slab_scale=None, spike_scale=None, seed=None)
+    # Test both scales and seed are None case (automatic scale determination) with dimensionwise noise application
+    ad_auto = Adapter().nnpe("y1", slab_scale=None, spike_scale=None, per_dimension=True, seed=None)
     result_training_auto = ad_auto(random_data, stage="training")
     assert not np.allclose(result_training_auto["y1"], random_data["y1"])
     for k, v in random_data.items():

--- a/tests/test_adapters/test_adapters.py
+++ b/tests/test_adapters/test_adapters.py
@@ -349,3 +349,30 @@ def test_nnpe(random_data):
     deserialized_auto = deserialize(serialized_auto)
     reserialized_auto = serialize(deserialized_auto)
     assert keras.tree.lists_to_tuples(serialized_auto) == keras.tree.lists_to_tuples(serialize(reserialized_auto))
+
+    # Test dimensionwise versus global noise application (per_dimension=True vs per_dimension=False)
+    # Create data with second dimension having higher variance
+    data_shape = (32, 16, 1)
+    rng = np.random.default_rng(42)
+    zero = np.ones(shape=data_shape)
+    high = rng.normal(0, 100.0, size=data_shape)
+    var_data = {"x": np.concatenate([zero, high], axis=-1)}
+
+    # Apply dimensionwise and global adapters with automatic slab_scale scale determination
+    ad_partial_global = Adapter().nnpe("x", spike_scale=0, slab_scale=None, per_dimension=False, seed=42)
+    ad_partial_dim = Adapter().nnpe("x", spike_scale=[0, 1], slab_scale=None, per_dimension=True, seed=42)
+    res_dim = ad_partial_dim(var_data, stage="training")
+    res_glob = ad_partial_global(var_data, stage="training")
+
+    # Compute standard deviations of noise per last axis dimension
+    noise_dim = res_dim["x"] - var_data["x"]
+    noise_glob = res_glob["x"] - var_data["x"]
+    std_dim = np.std(noise_dim, axis=(0, 1))
+    std_glob = np.std(noise_glob, axis=(0, 1))
+
+    # Dimensionwise should assign zero noise, global some noise to zero-variance dimension
+    assert std_dim[0] == 0
+    assert std_glob[0] > 0
+    # Both should assign noise to high-variance dimension
+    assert std_dim[1] > 0
+    assert std_glob[1] > 0

--- a/tests/test_adapters/test_adapters.py
+++ b/tests/test_adapters/test_adapters.py
@@ -304,7 +304,7 @@ def test_nnpe(random_data):
     import numpy as np
     from bayesflow.adapters import Adapter
 
-    ad = Adapter().nnpe(["x1"], slab_scale=1.0, spike_scale=1.0, seed=42)
+    ad = Adapter().nnpe("x1", slab_scale=1.0, spike_scale=1.0, seed=42)
     result_training = ad(random_data, stage="training")
     result_validation = ad(random_data, stage="validation")
     result_inference = ad(random_data, stage="inference")


### PR DESCRIPTION
Introduces a new adapter class, `Nnpe`, which implements Noisy Neural Posterior Estimation (NNPE) as described in [Ward et al. (2022)](https://proceedings.neurips.cc/paper_files/paper/2022/file/db0eac6747e3631eb91095cd76065611-Paper-Conference.pdf). NNPE augments training data with additive noise from a spike-and-slab distribution (mixture of Cauchy and Normal noise), aiming to improve robustness for noisy real world data by extending the scope of the training data. While the specific noise distributions seem to be mostly motivated by their usage in the non-amortized RNPE method proposed in the same paper, it proved to be a quick-and-easy improvement for situations where one expects the presence of similarly distributed noise [in our recent benchmarks](https://arxiv.org/abs/2502.04949).

I tried to incorporate all best practices from existing adapter classes, but would be thankful for a thorough check of the implemented changes and the clarity of the provided explanations. I used a `seed` argument instead of passing an `rng` for easier serialization, but there might be a more elegant way.