### PR TITLE
Align diffusion model with other inference networks and remove deprecation warnings

### DIFF
--- a/bayesflow/experimental/diffusion_model/__init__.py
+++ b/bayesflow/experimental/diffusion_model/__init__.py
@@ -1,7 +1,5 @@
 from .diffusion_model import DiffusionModel
-from .noise_schedule import NoiseSchedule
-from .cosine_noise_schedule import CosineNoiseSchedule
-from .edm_noise_schedule import EDMNoiseSchedule
+from bayesflow.experimental.diffusion_model.schedules.cosine_noise_schedule import CosineNoiseSchedule
 from .dispatch import find_noise_schedule
 
 from ...utils._docs import _add_imports_to_all

--- a/bayesflow/experimental/diffusion_model/diffusion_model.py
+++ b/bayesflow/experimental/diffusion_model/diffusion_model.py
@@ -17,8 +17,10 @@ from bayesflow.utils import (
     logging,
     tensor_utils,
 )
-from .dispatch import find_noise_schedule
 from bayesflow.utils.serialization import serialize, deserialize, serializable
+
+from schedules.noise_schedule import NoiseSchedule
+from .dispatch import find_noise_schedule
 
 
 # disable module check, use potential module after moving from experimental
@@ -42,7 +44,7 @@ class DiffusionModel(InferenceNetwork):
     }
 
     INTEGRATE_DEFAULT_CONFIG = {
-        "method": "euler",  # or euler_maruyama
+        "method": "euler",
         "steps": 250,
     }
 
@@ -50,9 +52,12 @@ class DiffusionModel(InferenceNetwork):
         self,
         *,
         subnet: str | type = "mlp",
-        integrate_kwargs: dict[str, any] = None,
-        noise_schedule: Literal["edm", "cosine"] | dict | type = "edm",
+        noise_schedule: Literal["edm", "cosine"] | NoiseSchedule | type = "edm",
         prediction_type: Literal["velocity", "noise", "F"] = "F",
+        loss_type: Literal["velocity", "noise", "F"] = "noise",
+        subnet_kwargs: dict[str, any] = None,
+        schedule_kwargs: dict[str, any] = None,
+        integrate_kwargs: dict[str, any] = None,
         **kwargs,
     ):
         """
@@ -72,48 +77,44 @@ class DiffusionModel(InferenceNetwork):
         integrate_kwargs : dict[str, any], optional
             Additional keyword arguments for the integration process. Default is None.
         noise_schedule : Literal['edm', 'cosine'], dict or type, optional
-            The noise schedule used for the diffusion process. Can be "cosine" or "edm" or a custom noise schedule.
-            You can also pass a dictionary with the configuration for the noise schedule, e.g.,
-                {'name': cosine, 's_shift_cosine': 1.0}
-            Default is "edm".
+            The noise schedule used for the diffusion process. Default is "F"
+        loss_type: Literal['velocity', 'noise', 'F'], optional
+            The type los loss used in the diffusion model. Default is "noise".
         prediction_type: Literal['velocity', 'noise', 'F'], optional
-            The type of prediction used in the diffusion model. Can be "velocity", "noise" or "F" (EDM).
-             Default is "F".
+            The type of prediction used in the diffusion model. Default is "F".
         **kwargs
             Additional keyword arguments passed to the subnet and other components.
         """
         super().__init__(base_distribution="normal", **kwargs)
 
-        self.noise_schedule = find_noise_schedule(noise_schedule)
-        self.noise_schedule.validate()
-
-        if prediction_type not in ["noise", "velocity", "F"]:  # F is EDM
+        if prediction_type not in ["noise", "velocity", "F"]:
             raise TypeError(f"Unknown prediction type: {prediction_type}")
-        self._prediction_type = prediction_type
-        self._loss_type = kwargs.get("loss_type", "noise")
-        if self._loss_type not in ["noise", "velocity", "F"]:
-            raise TypeError(f"Unknown loss type: {self._loss_type}")
-        if self._loss_type != "noise":
+
+        if loss_type not in ["noise", "velocity", "F"]:
+            raise TypeError(f"Unknown loss type: {loss_type}")
+
+        if loss_type != "noise":
             logging.warning(
-                "the standard schedules have weighting functions defined for the noise prediction loss. "
-                "You might want to replace them, if you use a different loss function."
+                "The standard schedules have weighting functions defined for the noise prediction loss. "
+                "You might want to replace them if you are using a different loss function."
             )
 
-        # clipping of prediction (after it was transformed to x-prediction)
-        # keeping this private for now, as it is usually not required in SBI and somewhat dangerous
-        self._clip_x = kwargs.get("clip_x", None)
-        if self._clip_x is not None:
-            if len(self._clip_x) != 2 or self._clip_x[0] > self._clip_x[1]:
-                raise ValueError("'clip_x' has to be a list or tuple with the values [x_min, x_max]")
+        self._prediction_type = prediction_type
+        self._loss_type = loss_type
+
+        self.schedule_kwargs = schedule_kwargs or {}
+        self.noise_schedule = find_noise_schedule(noise_schedule, **self.schedule_kwargs)
+        self.noise_schedule.validate()
 
         self.integrate_kwargs = self.INTEGRATE_DEFAULT_CONFIG | (integrate_kwargs or {})
         self.seed_generator = keras.random.SeedGenerator()
 
+        subnet_kwargs = subnet_kwargs or {}
         if subnet == "mlp":
-            self.subnet = find_network(subnet, **self.MLP_DEFAULT_CONFIG)
-        else:
-            self.subnet = find_network(subnet)
-        self.output_projector = keras.layers.Dense(units=None, bias_initializer="zeros")
+            subnet_kwargs = DiffusionModel.MLP_DEFAULT_CONFIG | subnet_kwargs
+        self.subnet = find_network(subnet, **subnet_kwargs)
+
+        self.output_projector = keras.layers.Dense(units=None, bias_initializer="zeros", name="output_projector")
 
     def build(self, xz_shape: Shape, conditions_shape: Shape = None) -> None:
         if self.built:
@@ -142,9 +143,10 @@ class DiffusionModel(InferenceNetwork):
         config = {
             "subnet": self.subnet,
             "noise_schedule": self.noise_schedule,
-            "integrate_kwargs": self.integrate_kwargs,
             "prediction_type": self._prediction_type,
             "loss_type": self._loss_type,
+            "schedule_kwargs": self.schedule_kwargs,
+            "integrate_kwargs": self.integrate_kwargs,
         }
         return base_config | serialize(config)
 
@@ -172,8 +174,6 @@ class DiffusionModel(InferenceNetwork):
         else:  # "score"
             x = (z + sigma_t**2 * pred) / alpha_t
 
-        if self._clip_x is not None:
-            x = ops.clip(x, self._clip_x[0], self._clip_x[1])
         return x
 
     def velocity(
@@ -193,6 +193,7 @@ class DiffusionModel(InferenceNetwork):
             xtc = tensor_utils.concatenate_valid([xz, self._transform_log_snr(log_snr_t)], axis=-1)
         else:
             xtc = tensor_utils.concatenate_valid([xz, self._transform_log_snr(log_snr_t), conditions], axis=-1)
+
         pred = self.output_projector(self.subnet(xtc, training=training), training=training)
 
         x_pred = self.convert_prediction_to_x(pred=pred, z=xz, alpha_t=alpha_t, sigma_t=sigma_t, log_snr_t=log_snr_t)
@@ -211,13 +212,29 @@ class DiffusionModel(InferenceNetwork):
 
         return out
 
-    def compute_diffusion_term(
+    def diffusion_term(
         self,
         xz: Tensor,
         time: float | Tensor,
         training: bool = False,
     ) -> Tensor:
-        # calculate the current noise level and transform into correct shape
+        """
+        Compute the diffusion term (standard deviation of the noise) for a given time.
+
+        Parameters
+        ----------
+        xz : Tensor
+            Input tensor with shape [..., D], typically representing the latent state or concatenated variables.
+        time : float or Tensor
+            The diffusion time step(s). Can be a scalar or a tensor broadcastable to the shape of `xz`.
+        training : bool, optional
+            Whether to use the training noise schedule (default is False).
+
+        Returns
+        -------
+        Tensor
+            The diffusion term tensor with shape matching `xz` except for the last dimension, which is set to 1.
+        """
         log_snr_t = expand_right_as(self.noise_schedule.get_log_snr(t=time, training=training), xz)
         log_snr_t = ops.broadcast_to(log_snr_t, ops.shape(xz)[:-1] + (1,))
         g_squared = self.noise_schedule.get_drift_diffusion(log_snr_t=log_snr_t)
@@ -258,9 +275,13 @@ class DiffusionModel(InferenceNetwork):
         training: bool = False,
         **kwargs,
     ) -> Tensor | tuple[Tensor, Tensor]:
-        integrate_kwargs = {"start_time": 0.0, "stop_time": 1.0}
-        integrate_kwargs = integrate_kwargs | self.integrate_kwargs
-        integrate_kwargs = integrate_kwargs | kwargs
+        integrate_kwargs = {
+            **self.integrate_kwargs,
+            "start_time": kwargs.pop("start_time", 0.0),
+            "stop_time": kwargs.pop("stop_top", 1),
+            **kwargs,
+        }
+
         if integrate_kwargs["method"] == "euler_maruyama":
             raise ValueError("Stochastic methods are not supported for forward integration.")
 
@@ -338,7 +359,7 @@ class DiffusionModel(InferenceNetwork):
                 }
 
             def diffusion(time, xz):
-                return {"xz": self.compute_diffusion_term(xz, time=time, training=training)}
+                return {"xz": self.diffusion_term(xz, time=time, training=training)}
 
             state = integrate_stochastic(
                 drift_fn=deltas,
@@ -382,7 +403,7 @@ class DiffusionModel(InferenceNetwork):
 
         # sample training diffusion time as low discrepancy sequence to decrease variance
         u0 = keras.random.uniform(shape=(1,), dtype=ops.dtype(x), seed=self.seed_generator)
-        i = ops.arange(0, ops.shape(x)[0], dtype=ops.dtype(x))  # tensor of indices
+        i = ops.arange(0, ops.shape(x)[0], dtype=ops.dtype(x))
         t = (u0 + i / ops.cast(ops.shape(x)[0], dtype=ops.dtype(x))) % 1
 
         # calculate the noise level
@@ -409,16 +430,17 @@ class DiffusionModel(InferenceNetwork):
             pred=pred, z=diffused_x, alpha_t=alpha_t, sigma_t=sigma_t, log_snr_t=log_snr_t
         )
 
-        # Calculate loss
         if self._loss_type == "noise":
             # convert x to epsilon prediction
             noise_pred = (diffused_x - alpha_t * x_pred) / sigma_t
             loss = weights_for_snr * ops.mean((noise_pred - eps_t) ** 2, axis=-1)
+
         elif self._loss_type == "velocity":
             # convert x to velocity prediction
             velocity_pred = (alpha_t * diffused_x - x_pred) / sigma_t
             v_t = alpha_t * eps_t - sigma_t * x
             loss = weights_for_snr * ops.mean((velocity_pred - v_t) ** 2, axis=-1)
+
         elif self._loss_type == "F":
             # convert x to F prediction
             sigma_data = self.noise_schedule.sigma_data if hasattr(self.noise_schedule, "sigma_data") else 1.0
@@ -427,6 +449,7 @@ class DiffusionModel(InferenceNetwork):
             f_pred = x1 * x_pred - x2 * diffused_x
             f_t = x1 * x - x2 * diffused_x
             loss = weights_for_snr * ops.mean((f_pred - f_t) ** 2, axis=-1)
+
         else:
             raise ValueError(f"Unknown loss type: {self._loss_type}")
 

--- a/bayesflow/experimental/diffusion_model/diffusion_model.py
+++ b/bayesflow/experimental/diffusion_model/diffusion_model.py
@@ -19,7 +19,7 @@ from bayesflow.utils import (
 )
 from bayesflow.utils.serialization import serialize, deserialize, serializable
 
-from schedules.noise_schedule import NoiseSchedule
+from .schedules.noise_schedule import NoiseSchedule
 from .dispatch import find_noise_schedule
 
 

--- a/bayesflow/experimental/diffusion_model/dispatch.py
+++ b/bayesflow/experimental/diffusion_model/dispatch.py
@@ -1,5 +1,6 @@
 from functools import singledispatch
-from .noise_schedule import NoiseSchedule
+
+from .schedules.noise_schedule import NoiseSchedule
 
 
 @singledispatch
@@ -16,32 +17,15 @@ def _(noise_schedule: NoiseSchedule):
 def _(name: str, *args, **kwargs):
     match name.lower():
         case "cosine":
-            from .cosine_noise_schedule import CosineNoiseSchedule
+            from .schedules import CosineNoiseSchedule
 
-            return CosineNoiseSchedule()
+            return CosineNoiseSchedule(*args, **kwargs)
         case "edm":
-            from .edm_noise_schedule import EDMNoiseSchedule
+            from .schedules import EDMNoiseSchedule
 
-            return EDMNoiseSchedule()
+            return EDMNoiseSchedule(*args, **kwargs)
         case other:
             raise ValueError(f"Unsupported noise schedule name: '{other}'.")
-
-
-@find_noise_schedule.register
-def _(config: dict, *args, **kwargs):
-    name = config.get("name", "").lower()
-    params = {k: v for k, v in config.items() if k != "name"}
-    match name:
-        case "cosine":
-            from .cosine_noise_schedule import CosineNoiseSchedule
-
-            return CosineNoiseSchedule(**params)
-        case "edm":
-            from .edm_noise_schedule import EDMNoiseSchedule
-
-            return EDMNoiseSchedule(**params)
-        case other:
-            raise ValueError(f"Unsupported noise schedule config: '{other}'.")
 
 
 @find_noise_schedule.register

--- a/bayesflow/experimental/diffusion_model/schedules/__init__.py
+++ b/bayesflow/experimental/diffusion_model/schedules/__init__.py
@@ -1,0 +1,2 @@
+from .cosine_noise_schedule import CosineNoiseSchedule
+from .edm_noise_schedule import EDMNoiseSchedule

--- a/bayesflow/experimental/diffusion_model/schedules/cosine_noise_schedule.py
+++ b/bayesflow/experimental/diffusion_model/schedules/cosine_noise_schedule.py
@@ -1,5 +1,5 @@
 import math
-from typing import Union, Literal
+from typing import Literal
 
 from keras import ops
 
@@ -14,7 +14,14 @@ from .noise_schedule import NoiseSchedule
 class CosineNoiseSchedule(NoiseSchedule):
     """Cosine noise schedule for diffusion models. This schedule is based on the cosine schedule from [1].
 
-    [1] Diffusion Models Beat GANs on Image Synthesis: Dhariwal and Nichol (2022)
+    A cosine schedule is a popular technique for controlling how the variance (noise level) or
+    learning rate evolves during the training of diffusion models. It was proposed as an improvement
+    over the original linear beta schedule in [2]
+
+    [1] Dhariwal, P., & Nichol, A. (2021). Diffusion models beat gans on image synthesis.
+    Advances in Neural Information Processing Systems, 34, 8780-8794.
+    [2] Ho, J., Jain, A., & Abbeel, P. (2020). Denoising diffusion probabilistic models.
+    Advances in Neural Information Processing Systems, 33, 6840-6851.
     """
 
     def __init__(
@@ -51,12 +58,12 @@ class CosineNoiseSchedule(NoiseSchedule):
     def _truncated_t(self, t: Tensor) -> Tensor:
         return self._t_min + (self._t_max - self._t_min) * t
 
-    def get_log_snr(self, t: Union[float, Tensor], training: bool) -> Tensor:
+    def get_log_snr(self, t: Tensor | float, training: bool) -> Tensor:
         """Get the log signal-to-noise ratio (lambda) for a given diffusion time."""
         t_trunc = self._truncated_t(t)
         return -2 * ops.log(ops.tan(math.pi * t_trunc * 0.5)) + 2 * self._shift
 
-    def get_t_from_log_snr(self, log_snr_t: Union[Tensor, float], training: bool) -> Tensor:
+    def get_t_from_log_snr(self, log_snr_t: Tensor | float, training: bool) -> Tensor:
         """Get the diffusion time (t) from the log signal-to-noise ratio (lambda)."""
         # SNR = -2 * log(tan(pi*t/2)) => t = 2/pi * arctan(exp(-snr/2))
         return 2 / math.pi * ops.arctan(ops.exp((2 * self._shift - log_snr_t) * 0.5))
@@ -76,9 +83,15 @@ class CosineNoiseSchedule(NoiseSchedule):
         return -factor * dsnr_dt
 
     def get_config(self):
-        return dict(
-            min_log_snr=self.log_snr_min, max_log_snr=self.log_snr_max, shift=self._shift, weighting=self._weighting
-        )
+        base_config = super().get_config()
+        config = {
+            "min_log_snr": self.log_snr_min,
+            "max_log_snr": self.log_snr_max,
+            "shift": self._shift,
+            "weighting": self._weighting,
+        }
+
+        return base_config | config
 
     @classmethod
     def from_config(cls, config, custom_objects=None):

--- a/bayesflow/experimental/diffusion_model/schedules/edm_noise_schedule.py
+++ b/bayesflow/experimental/diffusion_model/schedules/edm_noise_schedule.py
@@ -1,5 +1,4 @@
 import math
-from typing import Union
 
 from keras import ops
 
@@ -15,7 +14,8 @@ class EDMNoiseSchedule(NoiseSchedule):
     """EDM noise schedule for diffusion models. This schedule is based on the EDM paper [1].
     This should be used with the F-prediction type in the diffusion model.
 
-    [1] Elucidating the Design Space of Diffusion-Based Generative Models: Karras et al. (2022)
+    [1] Karras, T., Aittala, M., Aila, T., & Laine, S. (2022). Elucidating the design space of diffusion-based
+    generative models. Advances in Neural Information Processing Systems, 35, 26565-26577.
     """
 
     def __init__(self, sigma_data: float = 1.0, sigma_min: float = 1e-4, sigma_max: float = 80.0):
@@ -26,7 +26,7 @@ class EDMNoiseSchedule(NoiseSchedule):
         ----------
         sigma_data : float, optional
             The standard deviation of the output distribution. Input of the network is scaled by this factor and
-            the weighting function is scaled by this factor as well.
+            the weighting function is scaled by this factor as well. Default is 1.0.
         sigma_min : float, optional
             The minimum noise level. Only relevant for sampling. Default is 1e-4.
         sigma_max : float, optional
@@ -50,21 +50,21 @@ class EDMNoiseSchedule(NoiseSchedule):
         self._log_snr_min_training = self.log_snr_min - 1  # one is never sampler during training
         self._log_snr_max_training = self.log_snr_max + 1  # 0 is almost surely never sampled during training
 
-    def get_log_snr(self, t: Union[float, Tensor], training: bool) -> Tensor:
+    def get_log_snr(self, t: float | Tensor, training: bool) -> Tensor:
         """Get the log signal-to-noise ratio (lambda) for a given diffusion time."""
         if training:
-            # SNR = -dist.icdf(t_trunc) # negative seems to be wrong in the paper in the Kingma paper
+            # SNR = -dist.icdf(t_trunc) # negative seems to be wrong in the Kingma paper
             loc = -2 * self.p_mean
             scale = 2 * self.p_std
             snr = loc + scale * ops.erfinv(2 * t - 1) * math.sqrt(2)
             snr = ops.clip(snr, x_min=self._log_snr_min_training, x_max=self._log_snr_max_training)
-        else:  # sampling
+        else:
             sigma_min_rho = self.sigma_min ** (1 / self.rho)
             sigma_max_rho = self.sigma_max ** (1 / self.rho)
             snr = -2 * self.rho * ops.log(sigma_max_rho + (1 - t) * (sigma_min_rho - sigma_max_rho))
         return snr
 
-    def get_t_from_log_snr(self, log_snr_t: Union[float, Tensor], training: bool) -> Tensor:
+    def get_t_from_log_snr(self, log_snr_t: float | Tensor, training: bool) -> Tensor:
         """Get the diffusion time (t) from the log signal-to-noise ratio (lambda)."""
         if training:
             # SNR = -dist.icdf(t_trunc) => t = dist.cdf(-snr)  # negative seems to be wrong in the Kingma paper
@@ -80,7 +80,7 @@ class EDMNoiseSchedule(NoiseSchedule):
             t = 1 - ((ops.exp(-log_snr_t / (2 * self.rho)) - sigma_max_rho) / (sigma_min_rho - sigma_max_rho))
         return t
 
-    def derivative_log_snr(self, log_snr_t: Tensor, training: bool) -> Tensor:
+    def derivative_log_snr(self, log_snr_t: Tensor, training: bool = False) -> Tensor:
         """Compute d/dt log(1 + e^(-snr(t))), which is used for the reverse SDE."""
         if training:
             raise NotImplementedError("Derivative of log SNR is not implemented for training mode.")
@@ -102,10 +102,13 @@ class EDMNoiseSchedule(NoiseSchedule):
     def get_weights_for_snr(self, log_snr_t: Tensor) -> Tensor:
         """Get weights for the signal-to-noise ratio (snr) for a given log signal-to-noise ratio (lambda)."""
         # for F-prediction: w = (ops.exp(-log_snr_t) + sigma_data^2) / (ops.exp(-log_snr_t)*sigma_data^2)
-        return ops.exp(-log_snr_t) / ops.square(self.sigma_data) + 1
+        return 1 + ops.exp(-log_snr_t) / ops.square(self.sigma_data)
 
     def get_config(self):
-        return dict(sigma_data=self.sigma_data, sigma_min=self.sigma_min, sigma_max=self.sigma_max)
+        base_config = super().get_config()
+        config = {"sigma_data": self.sigma_data, "sigma_min": self.sigma_min, "sigma_max": self.sigma_max}
+
+        return base_config | config
 
     @classmethod
     def from_config(cls, config, custom_objects=None):

--- a/bayesflow/experimental/free_form_flow/free_form_flow.py
+++ b/bayesflow/experimental/free_form_flow/free_form_flow.py
@@ -1,8 +1,6 @@
 import keras
 from keras import ops
 
-import warnings
-
 from bayesflow.distributions import Distribution
 from bayesflow.types import Tensor
 from bayesflow.utils import (
@@ -85,13 +83,6 @@ class FreeFormFlow(InferenceNetwork):
             Additional keyword arguments
         """
         super().__init__(base_distribution, **kwargs)
-
-        if encoder_subnet_kwargs or decoder_subnet_kwargs:
-            warnings.warn(
-                "Using `subnet_kwargs` is deprecated."
-                "Instead, instantiate the network yourself and pass the arguments directly.",
-                DeprecationWarning,
-            )
 
         encoder_subnet_kwargs = encoder_subnet_kwargs or {}
         decoder_subnet_kwargs = decoder_subnet_kwargs or {}

--- a/bayesflow/networks/consistency_models/consistency_model.py
+++ b/bayesflow/networks/consistency_models/consistency_model.py
@@ -3,8 +3,6 @@ from keras import ops
 
 import numpy as np
 
-import warnings
-
 from bayesflow.types import Tensor
 from bayesflow.utils import find_network, layer_kwargs, weighted_mean
 from bayesflow.utils.serialization import deserialize, serializable, serialize
@@ -75,13 +73,6 @@ class ConsistencyModel(InferenceNetwork):
         super().__init__(base_distribution="normal", **kwargs)
 
         self.total_steps = float(total_steps)
-
-        if subnet_kwargs:
-            warnings.warn(
-                "Using `subnet_kwargs` is deprecated."
-                "Instead, instantiate the network yourself and pass the arguments directly.",
-                DeprecationWarning,
-            )
 
         subnet_kwargs = subnet_kwargs or {}
         if subnet == "mlp":

--- a/bayesflow/networks/flow_matching/flow_matching.py
+++ b/bayesflow/networks/flow_matching/flow_matching.py
@@ -2,8 +2,6 @@ from collections.abc import Sequence
 
 import keras
 
-import warnings
-
 from bayesflow.distributions import Distribution
 from bayesflow.types import Shape, Tensor
 from bayesflow.utils import (
@@ -105,13 +103,6 @@ class FlowMatching(InferenceNetwork):
         self.loss_fn = keras.losses.get(loss_fn)
 
         self.seed_generator = keras.random.SeedGenerator()
-
-        if subnet_kwargs:
-            warnings.warn(
-                "Using `subnet_kwargs` is deprecated."
-                "Instead, instantiate the network yourself and pass the arguments directly.",
-                DeprecationWarning,
-            )
 
         subnet_kwargs = subnet_kwargs or {}
         if subnet == "mlp":

--- a/tests/test_networks/test_diffusion_model/conftest.py
+++ b/tests/test_networks/test_diffusion_model/conftest.py
@@ -3,14 +3,14 @@ import pytest
 
 @pytest.fixture()
 def cosine_noise_schedule():
-    from bayesflow.experimental.diffusion_model import CosineNoiseSchedule
+    from bayesflow.experimental.diffusion_model.schedules import CosineNoiseSchedule
 
     return CosineNoiseSchedule(min_log_snr=-12, max_log_snr=12, shift=0.1, weighting="likelihood_weighting")
 
 
 @pytest.fixture()
 def edm_noise_schedule():
-    from bayesflow.experimental.diffusion_model import EDMNoiseSchedule
+    from bayesflow.experimental.diffusion_model.schedules import EDMNoiseSchedule
 
     return EDMNoiseSchedule(sigma_data=10.0, sigma_min=1e-5, sigma_max=85.0)
 


### PR DESCRIPTION
This PR suggests a small refactor of the existing diffusion model implementation to align it a bit better with other inference networks. It also removes the deprecation warning, as discussed per https://github.com/bayesflow-org/bayesflow/issues/475. 

@arrjon @vpratz Can you please ensure that

- The following defaults make sense:
1. noise_schedule: Literal["edm", "cosine"] | NoiseSchedule | type = "edm",
2. prediction_type: Literal["velocity", "noise", "F"] = "F",
3. loss_type: Literal["velocity", "noise", "F"] = "noise",

- The function `get_weights_for_snr` of `edm_noise_schedule.py` is correct (L 102).
- Stop time should indeed be 0 and not some `epsilon` (L331 in `diffusion_model.py`)

I have removed the clipping option from the constructor, as this should be something that is potentially only passed during inference, akin to the number of steps in flow matching.