### PR TITLE
Fix typos in Linear_Regression_Starter.ipynb

### DIFF
--- a/examples/Linear_Regression_Starter.ipynb
+++ b/examples/Linear_Regression_Starter.ipynb
@@ -569,7 +569,7 @@
     "id": "NF1XmDmDBRyT"
    },
    "source": [
-    "Now, we are ready to train our approximator to learn posterior distributions for linear regression models. To achieve this, we will all `approximator.fit` passing the `simulator` and a bunch of hyperparameters that control how long we want to train.\n",
+    "Now, we are ready to train our approximator to learn posterior distributions for linear regression models. To achieve this, we will call `approximator.fit` passing the `simulator` and a bunch of hyperparameters that control how long we want to train.\n",
     "\n",
     "**Note**: when using JAX and the shape of your data differs in every batch (e.g., when observations vary), you will observe some compilation overhead during the first few steps. The total training time for this example is around 2 minutes on a standard laptop."
    ]
@@ -669,7 +669,7 @@
     "id": "nxCV-wdnDa1N"
    },
    "source": [
-    "Initial sanity checks of the posterior samples look good. `post_draws[\"beta\"]` has shape `(200, 2000, 2)` which makes sense since we asked for inference of a 200 data sets (first dimension is 200), for which we wanted to generated 1000 posterior samples (second dimension is 1000). The third dimension is 2, since the `beta` variable was defined as a vector of length 2 (intercept and slope)."
+    "Initial sanity checks of the posterior samples look good. `post_draws[\"beta\"]` has shape `(200, 1000, 2)` which makes sense since we asked for inference of a 200 data sets (first dimension is 200), for which we wanted to generated 1000 posterior samples (second dimension is 1000). The third dimension is 2, since the `beta` variable was defined as a vector of length 2 (intercept and slope)."
    ]
   },
   {


### PR DESCRIPTION
Fixed small typos in the linear regression example.

Sorry if the form of this correction doesn't match the contributing guidelines; there was little guidance about how to "correct" existing examples.