### PR TITLE
Quickfix: ensure that Dense layers in Sequential are built

### DIFF
--- a/bayesflow/networks/mlp/mlp.py
+++ b/bayesflow/networks/mlp/mlp.py
@@ -92,6 +92,8 @@ class MLP(keras.Sequential):
 
         for layer in self._layers:
             layer.build(input_shape)
+            if not layer.layers[0].built:
+                layer.layers[0].build(input_shape)
             input_shape = layer.compute_output_shape(input_shape)
 
     @classmethod


### PR DESCRIPTION
This is a quick fix to the problem described in #491. I think the problem originates from using the Ellipsis in the input shape to `Sequential`, which `Sequential` does not seem to process correctly, which `Dense` is apparently able to do.
@LarsKue Do you think this is a good way to fix this? We could also try to avoid the use of `Sequential` entirely, and use a custom class to avoid the issue you raised in https://github.com/keras-team/keras/issues/21158.