### PR TITLE
Fix trainable parameters in distributions

### DIFF
--- a/bayesflow/distributions/mixture.py
+++ b/bayesflow/distributions/mixture.py
@@ -144,7 +144,7 @@ class Mixture(Distribution):
 
         self._mixture_logits = self.add_weight(
             shape=(len(self.distributions),),
-            initializer=keras.initializers.get(self.mixture_logits),
+            initializer=keras.initializers.get(keras.ops.copy(self.mixture_logits)),
             dtype="float32",
             trainable=self.trainable_mixture,
         )


### PR DESCRIPTION
This PR fixes two issues for the distributions when trainable parameters are used.
- make the normalization constant depend on the trainable value, was using only the initial value
- use a copy for the values passed to `keras.initializers.get`, as the arrays seem to be freed for some reason, leading to a weird `RuntimeError: Array has been deleted with shape=float32[4].` when trying to access them.

I encountered this when preparing #519, where I added a test for this. To reproduce it, check out the PR and run `nox -- save dev tests/test_compatibility/test_distributions`.