### PR TITLE
Breaking changes: Fix bugs regarding counts in standardization layer

### DIFF
--- a/tests/test_approximators/test_approximator_standardization/test_approximator_standardization.py
+++ b/tests/test_approximators/test_approximator_standardization/test_approximator_standardization.py
@@ -1,6 +1,5 @@
 import keras
 from tests.utils import assert_models_equal
-import numpy as np
 
 
 def test_save_and_load(tmp_path, approximator, train_dataset, validation_dataset):
@@ -9,7 +8,8 @@ def test_save_and_load(tmp_path, approximator, train_dataset, validation_dataset
     approximator.build(data_shapes)
     for layer in approximator.standardize_layers.values():
         assert layer.built
-        np.testing.assert_allclose([c.value.numpy() for c in layer.count], 0.0)
+        for count in layer.count:
+            assert count == 0.0
     approximator.compute_metrics(**train_dataset[0])
 
     keras.saving.save_model(approximator, tmp_path / "model.keras")

--- a/tests/test_approximators/test_approximator_standardization/test_approximator_standardization.py
+++ b/tests/test_approximators/test_approximator_standardization/test_approximator_standardization.py
@@ -1,5 +1,6 @@
 import keras
 from tests.utils import assert_models_equal
+import numpy as np
 
 
 def test_save_and_load(tmp_path, approximator, train_dataset, validation_dataset):
@@ -8,7 +9,7 @@ def test_save_and_load(tmp_path, approximator, train_dataset, validation_dataset
     approximator.build(data_shapes)
     for layer in approximator.standardize_layers.values():
         assert layer.built
-        assert layer.count == 0
+        np.testing.assert_allclose([c.value.numpy() for c in layer.count], 0.0)
     approximator.compute_metrics(**train_dataset[0])
 
     keras.saving.save_model(approximator, tmp_path / "model.keras")

--- a/tests/test_approximators/test_build.py
+++ b/tests/test_approximators/test_build.py
@@ -14,4 +14,5 @@ def test_build(approximator, simulator, batch_size, adapter):
     approximator.build(batch_shapes)
     for layer in approximator.standardize_layers.values():
         assert layer.built
-        assert layer.count == 0
+        for count in layer.count:
+            assert count == 0.0


### PR DESCRIPTION
Fixes #524 and a related bug.

- count was accidentally updated multiple times when multiple inputs were present, leading to wrong values (#524)
- count was calculated wrongly, as only the batch size was used. Correct is the product of all reduce dimensions. This lead to wrong standard deviations.

While the batch dimension is the same for all inputs, the size of the second dimension might vary. For this reason, we need to introduce an input-specific `count` variable. This change is serialization breaking.

I added the test `test_nested_accuracy_forward` to reproduce the bugs. It fails on `dev` and is fixed by this PR.