### PR TITLE
Custom test quantity support for calibration_ecdf

### DIFF
--- a/bayesflow/diagnostics/plots/calibration_ecdf.py
+++ b/bayesflow/diagnostics/plots/calibration_ecdf.py
@@ -1,6 +1,7 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 
 import numpy as np
+import keras
 import matplotlib.pyplot as plt
 
 from ...utils.plot_utils import prepare_plot_data, add_titles_and_labels, prettify_subplots
@@ -13,6 +14,7 @@ def calibration_ecdf(
     targets: Mapping[str, np.ndarray] | np.ndarray,
     variable_keys: Sequence[str] = None,
     variable_names: Sequence[str] = None,
+    test_quantities: dict[str, Callable] = None,
     difference: bool = False,
     stacked: bool = False,
     rank_type: str | np.ndarray = "fractional",
@@ -78,6 +80,18 @@ def calibration_ecdf(
     variable_names    : list or None, optional, default: None
         The parameter names for nice plot titles.
         Inferred if None. Only relevant if `stacked=False`.
+    test_quantities   : dict or None, optional, default: None
+        A dict that maps plot titles to functions that compute
+        test quantities based on estimate/target draws.
+
+        The dict keys are automatically added to ``variable_keys``
+        and ``variable_names``.
+        Test quantity functions are expected to accept a dict of draws with
+        shape ``(batch_size, ...)`` as the first (typically only)
+        positional argument and return an NumPy array of shape
+        ``(batch_size,)``.
+        The functions do not have to deal with an additional
+        sample dimension, as appropriate reshaping is done internally.
     figsize           : tuple or None, optional, default: None
         The figure size passed to the matplotlib constructor.
         Inferred if None.
@@ -119,6 +133,32 @@ def calibration_ecdf(
     ValueError
         If an unknown `rank_type` is passed.
     """
+
+    # Optionally, compute and prepend test quantities from draws
+    if test_quantities is not None:
+        # Prepare empty mapping to hold test quantity values
+        test_quantities_estimates = {}
+        test_quantities_targets = {}
+
+        for key, test_quantity_func in test_quantities.items():
+            # Apply test_quantity_func to draws
+            tq_targets = test_quantity_func(data=targets)
+            test_quantities_targets[key] = np.expand_dims(tq_targets, axis=1)
+
+            # We assume test_quantity_func can only handle a 1D batch_size, so estimates
+            # which have shape (num_conditions, num_post_samples, ...) must be flattend first.
+            num_conditions, num_post_samples = next(iter(estimates.values())).shape[:2]
+            flattened_estimates = keras.tree.map_structure(lambda t: np.reshape(t, (-1, *t.shape[2:])), estimates)
+            flat_tq_estimates = test_quantity_func(data=flattened_estimates)
+            test_quantities_estimates[key] = np.reshape(flat_tq_estimates, (num_conditions, num_post_samples, 1))
+
+        # Add custom test quantities to variable keys and names for plotting
+        variable_keys = list(test_quantities.keys()) + variable_keys
+        variable_names = list(test_quantities.keys()) + variable_names
+
+        # Prepend test quantities to draws
+        estimates = test_quantities_estimates | estimates
+        targets = test_quantities_targets | targets
 
     plot_data = prepare_plot_data(
         estimates=estimates,

--- a/bayesflow/diagnostics/plots/calibration_ecdf.py
+++ b/bayesflow/diagnostics/plots/calibration_ecdf.py
@@ -146,11 +146,11 @@ def calibration_ecdf(
             test_quantities_targets[key] = np.expand_dims(tq_targets, axis=1)
 
             # We assume test_quantity_func can only handle a 1D batch_size, so estimates
-            # which have shape (num_conditions, num_post_samples, ...) must be flattend first.
-            num_conditions, num_post_samples = next(iter(estimates.values())).shape[:2]
+            # which have shape (num_conditions, num_samples, ...) must be flattend first.
+            num_conditions, num_samples = next(iter(estimates.values())).shape[:2]
             flattened_estimates = keras.tree.map_structure(lambda t: np.reshape(t, (-1, *t.shape[2:])), estimates)
             flat_tq_estimates = test_quantity_func(data=flattened_estimates)
-            test_quantities_estimates[key] = np.reshape(flat_tq_estimates, (num_conditions, num_post_samples, 1))
+            test_quantities_estimates[key] = np.reshape(flat_tq_estimates, (num_conditions, num_samples, 1))
 
         # Add custom test quantities to variable keys and names for plotting
         variable_keys = list(test_quantities.keys()) + variable_keys

--- a/bayesflow/diagnostics/plots/calibration_ecdf.py
+++ b/bayesflow/diagnostics/plots/calibration_ecdf.py
@@ -153,8 +153,21 @@ def calibration_ecdf(
             test_quantities_estimates[key] = np.reshape(flat_tq_estimates, (num_conditions, num_samples, 1))
 
         # Add custom test quantities to variable keys and names for plotting
-        variable_keys = list(test_quantities.keys()) + variable_keys
-        variable_names = list(test_quantities.keys()) + variable_names
+        # keys and names are set to the test_quantities dict keys
+        test_quantities_names = list(test_quantities.keys())
+
+        # By default all keys in estimates are selected
+        if variable_keys is None:
+            variable_keys = list(estimates.keys())
+
+        # If variable_names are present, concatenate them to the test_quantities_names
+        if isinstance(variable_names, list):
+            variable_names = test_quantities_names + variable_names
+        # If variable_names are None, they will stay None here and are subsequently inferred.
+
+        # After the defaults are handled, we simply concatenate the keys
+        # for test quantities and regular variables.
+        variable_keys = test_quantities_names + variable_keys
 
         # Prepend test quantities to draws
         estimates = test_quantities_estimates | estimates

--- a/bayesflow/utils/dict_utils.py
+++ b/bayesflow/utils/dict_utils.py
@@ -282,6 +282,10 @@ def dicts_to_arrays(
         Ground-truth values corresponding to the estimates. Must match the structure and dimensionality
         of `estimates` in terms of first and last axis.
 
+    priors : dict[str, ndarray] or ndarray, optional (default = None)
+        Prior draws. Must match the structure and dimensionality
+        of `estimates` in terms of first and last axis.
+
     dataset_ids : Sequence of integers indexing the datasets to select (default = None).
         By default, use all datasets.
 

--- a/bayesflow/utils/plot_utils.py
+++ b/bayesflow/utils/plot_utils.py
@@ -23,7 +23,7 @@ def prepare_plot_data(
     figsize: tuple = None,
     stacked: bool = False,
     default_name: str = "v",
-) -> Mapping[str, Any]:
+) -> dict[str, Any]:
     """
     Procedural wrapper that encompasses all preprocessing steps, including shape-checking, parameter name
     generation, layout configuration, figure initialization, and collapsing of axes.
@@ -56,6 +56,12 @@ def prepare_plot_data(
         Whether the plots are stacked horizontally
     default_name      : str, optional (default = "v")
         The default name to use for estimates if None provided
+
+    Returns
+    -------
+    plot_data : dict[str, Any]
+        A dictionary containing all preprocessed data and plotting objects required for visualization,
+        including estimates, targets, variable names, figure, axes, and layout configuration.
     """
 
     plot_data = dicts_to_arrays(


### PR DESCRIPTION
This PR adds a keyword argument to calibration_ecdf for custom test quantities in simulation-based calibration checking (SBC). 

The benefits of custom test quantities are detailed in
Modrák, M., Moon, A. H., Kim, S., Bürkner, P., Huurre, N., Faltejsková, K., Gelman, A., & Vehtari, A. (2025). Simulation-Based Calibration Checking for Bayesian Computation: The Choice of Test Quantities Shapes Sensitivity. Bayesian Analysis, 20(2). https://doi.org/10.1214/23-BA1404

# Example

```python
# after training a workflow and sampling val_sim from a simulator

f = bf.diagnostics.calibration_ecdf(
    workflow.sample(conditions=val_sims, num_samples=num_post_samples),
    val_sims,
    test_quantities={  # this argument is new
        r"$\theta_1 + \theta_2$": lambda data: np.sum(data["parameters"], axis=-1),
        r"$\theta_1 - \theta_2$": lambda data: np.sum(data["parameters"] * np.array([[1, -1]]), axis=-1),
        r"$\theta_1 \cdot \theta_2$": lambda data: np.prod(data["parameters"], axis=-1),
    }, 
    difference=True, variable_keys=["parameters"], variable_names=[r"$\theta_1$", r"$\theta_2$"],
)
```
![image](https://github.com/user-attachments/assets/74a97407-f90a-46be-a023-6576d615e079)
