### PR TITLE
Breaking: parameterize MVNormalScore by inverse cholesky factor to improve stability

### DIFF
--- a/bayesflow/networks/standardization/standardization.py
+++ b/bayesflow/networks/standardization/standardization.py
@@ -117,6 +117,9 @@ class Standardization(keras.Layer):
                     case "left_side_scale":
                         # x_ij = sigma_i * x_ij'
                         out = val * keras.ops.moveaxis(std, -1, -2)
+                    case "right_side_scale_inverse":
+                        # x_ij = x_ij' / sigma_j
+                        out = val / std
                     case _:
                         out = val
 

--- a/bayesflow/scores/multivariate_normal_score.py
+++ b/bayesflow/scores/multivariate_normal_score.py
@@ -58,7 +58,7 @@ class MultivariateNormalScore(ParametricDistributionScore):
         Compute the log probability density of a multivariate Gaussian distribution.
 
         This function calculates the log probability density for each sample in `x` under a
-        multivariate Gaussian distribution with the given `mean` and `cov_chol`.
+        multivariate Gaussian distribution with the given `mean` and `precision_cholesky_factor`.
 
         The computation includes the determinant of the precision matrix, its inverse, and the quadratic
         form in the exponential term of the Gaussian density function.
@@ -122,7 +122,7 @@ class MultivariateNormalScore(ParametricDistributionScore):
         Tensor
             A tensor of shape (batch_size, num_samples, D) containing the generated samples.
         """
-        cov_chol = keras.ops.inv(precision_cholesky_factor)
+        covariance_cholesky_factor = keras.ops.inv(precision_cholesky_factor)
         if len(batch_shape) == 1:
             batch_shape = (1,) + tuple(batch_shape)
         batch_size, num_samples = batch_shape
@@ -139,7 +139,7 @@ class MultivariateNormalScore(ParametricDistributionScore):
         # Use Cholesky decomposition to generate samples
         normal_samples = keras.random.normal((*batch_shape, dim))
 
-        scaled_normal = keras.ops.einsum("ijk,ilk->ilj", cov_chol, normal_samples)
+        scaled_normal = keras.ops.einsum("ijk,ilk->ilj", covariance_cholesky_factor, normal_samples)
         samples = mean[:, None, :] + scaled_normal
 
         return samples

--- a/bayesflow/scores/multivariate_normal_score.py
+++ b/bayesflow/scores/multivariate_normal_score.py
@@ -27,7 +27,7 @@ class MultivariateNormalScore(ParametricDistributionScore):
     For more information see :py:class:`ScoringRule`.
     """
 
-    TRANSFORMATION_TYPE: dict[str, str] = {"cov_chol_inv": "left_side_scale"}
+    TRANSFORMATION_TYPE: dict[str, str] = {"cov_chol_inv": "right_side_scale_inverse"}
     """
     Marks covariance Cholesky factor head to handle de-standardization as for covariant rank-(0,2) tensors.
 

--- a/bayesflow/utils/tensor_utils.py
+++ b/bayesflow/utils/tensor_utils.py
@@ -311,7 +311,7 @@ def tree_stack(structures: Sequence[T], axis: int = 0, numpy: bool = None) -> T:
     return keras.tree.map_structure(stack, *structures)
 
 
-def fill_triangular_matrix(x: Tensor, upper: bool = False, positive_diag: bool = False):
+def fill_triangular_matrix(x: Tensor, upper: bool = False):
     """
     Reshapes a batch of matrix elements into a triangular matrix (either upper or lower).
 

--- a/tests/test_approximators/test_fit.py
+++ b/tests/test_approximators/test_fit.py
@@ -3,7 +3,6 @@ import re
 import pytest
 import io
 from contextlib import redirect_stdout
-from tests.utils import check_approximator_multivariate_normal_score
 
 
 @pytest.mark.skip(reason="not implemented")
@@ -20,9 +19,6 @@ def test_fit(amortizer, dataset):
 
 
 def test_loss_progress(approximator, train_dataset, validation_dataset):
-    # as long as MultivariateNormalScore is unstable, skip fit progress test
-    check_approximator_multivariate_normal_score(approximator)
-
     approximator.compile(optimizer="AdamW")
     num_epochs = 3
 

--- a/tests/test_approximators/test_log_prob.py
+++ b/tests/test_approximators/test_log_prob.py
@@ -1,12 +1,10 @@
 import keras
 import numpy as np
-from tests.utils import check_combination_simulator_adapter, check_approximator_multivariate_normal_score
+from tests.utils import check_combination_simulator_adapter
 
 
 def test_approximator_log_prob(approximator, simulator, batch_size, adapter):
     check_combination_simulator_adapter(simulator, adapter)
-    # as long as MultivariateNormalScore is unstable, skip
-    check_approximator_multivariate_normal_score(approximator)
 
     num_batches = 4
     data = simulator.sample((num_batches * batch_size,))

--- a/tests/test_approximators/test_sample.py
+++ b/tests/test_approximators/test_sample.py
@@ -1,11 +1,9 @@
 import keras
-from tests.utils import check_combination_simulator_adapter, check_approximator_multivariate_normal_score
+from tests.utils import check_combination_simulator_adapter
 
 
 def test_approximator_sample(approximator, simulator, batch_size, adapter):
     check_combination_simulator_adapter(simulator, adapter)
-    # as long as MultivariateNormalScore is unstable, skip
-    check_approximator_multivariate_normal_score(approximator)
 
     num_batches = 4
     data = simulator.sample((num_batches * batch_size,))

--- a/tests/utils/check_combinations.py
+++ b/tests/utils/check_combinations.py
@@ -19,13 +19,3 @@ def check_combination_simulator_adapter(simulator, adapter):
         # to be used as sample weight, no error is raised currently.
         # Don't use this fixture combination for further tests.
         pytest.skip(reason="Do not use this fixture combination for further tests")  # TODO: better reason
-
-
-def check_approximator_multivariate_normal_score(approximator):
-    from bayesflow.approximators import PointApproximator
-    from bayesflow.scores import MultivariateNormalScore
-
-    if isinstance(approximator, PointApproximator):
-        for score in approximator.inference_network.scores.values():
-            if isinstance(score, MultivariateNormalScore):
-                pytest.skip(reason="MultivariateNormalScore is unstable")


### PR DESCRIPTION
The log_prob of `MultivariateNormalScore` can be calculated using only the inverse Cholesky factor L^{-1}, but currently the Cholesky factor L is used as well, requiring the calculation of the inverse. Calculating the inverse can lead to errors due to numerical instabilities in the matrix inversion, so parameterizing the inverse directly and dropping L from the log_prob is beneficial. This also stabilizes the initial loss, and speeds up computation.

This commit contains two further optimizations. Moving the computation of the precision matrix into the einsum, and using the sum of the logs instead of the log of a product.

Open question:
- Is the transformation behavior "left_side_scale" still correct for the inverse matrix? @han-ol 
- Is "cov_chol_inv" a good name, or do we want to change it?

As the parameterization of the methods changes, this is a breaking change. As it resolves major stability problems for usage of the score in higher-dimensional problems, I thing it is worth including them anyway.

Thanks to @han-ol for support in fixing this problem.