### PR TITLE
Fix broken link to point estimation example

### DIFF
--- a/bayesflow/links/positive_definite.py
+++ b/bayesflow/links/positive_definite.py
@@ -43,8 +43,8 @@ class PositiveDefinite(keras.Layer):
 
         There are m nonzero elements of a lower triangular nxn matrix with m = n * (n + 1) / 2.
 
-        Example
-        -------
+        Examples
+        --------
         >>> PositiveDefinite().compute_output_shape((None, 3, 3))
         6
         """

--- a/docsrc/source/examples.rst
+++ b/docsrc/source/examples.rst
@@ -17,6 +17,6 @@ The corresponding Jupyter Notebooks are available :mainbranch:`here <examples/>`
    _examples/Bayesian_Experimental_Design.ipynb
    _examples/From_ABC_to_BayesFlow.ipynb
    _examples/One_Sample_TTest.ipynb
-   _examples/Lotka_Volterra_Point_Estimation_and_Expert_Stats.ipynb
+   _examples/Lotka_Volterra_Point_Estimation.ipynb
    _examples/Likelihood_Estimation.ipynb
    _examples/Multimodal_Data.ipynb


### PR DESCRIPTION
The example currently does not show in the docs due to the wrong link. Opening this PR to `main` so that we can quickly make it available on the website again.

Also fixes the examples section header in PositiveDefinite docstring.