### PR TITLE
Fix: optimizer was not used in workflow with multiple fits

### DIFF
--- a/bayesflow/workflows/basic_workflow.py
+++ b/bayesflow/workflows/basic_workflow.py
@@ -914,6 +914,7 @@ class BasicWorkflow(Workflow):
             self.optimizer = keras.optimizers.Adam(learning_rate, clipnorm=1.5)
         else:
             self.optimizer = keras.optimizers.AdamW(learning_rate, weight_decay=5e-3, clipnorm=1.5)
+        return self.optimizer
 
     def _fit(
         self,
@@ -955,9 +956,10 @@ class BasicWorkflow(Workflow):
             else:
                 kwargs["callbacks"] = [model_checkpoint_callback]
 
-        self.build_optimizer(epochs, dataset.num_batches, strategy=strategy)
-
-        if not self.approximator.built:
+        # returns None if no new optimizer was built and assigned to self.optimizer, which indicates we do not have
+        # to (re)compile the approximator.
+        optimizer = self.build_optimizer(epochs, dataset.num_batches, strategy=strategy)
+        if optimizer is not None:
             self.approximator.compile(optimizer=self.optimizer, metrics=kwargs.pop("metrics", None))
 
         try:


### PR DESCRIPTION
For the optimizer to be used, the approximator.compile function has to be called. This was not the case for repeated calls to `fit_...`, even with `keep_optimizer` set to `False`. I adapted the `setup_optimizer` function to match the description in its docstring, and made the compilation conditional on its output. The output indicates if a new optimizer was configured.

To reproduce, you can run the following code. In the version without the fix, one and two will give the same value, and three a different one. With the fix, all three produce different values, as expected.

```python
import bayesflow as bf
import keras

epochs = 2
num_batches_per_epoch = 10
batch_size = 4

simulator = bf.simulators.TwoMoons()
validation_data = simulator.sample(100)

workflow = bf.BasicWorkflow(
    simulator=simulator,
    standardize="all",
    inference_conditions="observables",
    inference_variables="parameters",
)

workflow.fit_online(
    num_batches_per_epoch=num_batches_per_epoch, epochs=epochs, validation_data=validation_data, batch_size=batch_size
)
print("first", workflow.approximator.trainable_weights[0][0])
workflow.fit_online(
    num_batches_per_epoch=num_batches_per_epoch, epochs=epochs, validation_data=validation_data, batch_size=batch_size
)
print("second", workflow.approximator.trainable_weights[0][0])
workflow.approximator.compile(optimizer=keras.optimizers.Adam())
workflow.fit_online(
    num_batches_per_epoch=num_batches_per_epoch, epochs=epochs, validation_data=validation_data, batch_size=batch_size
)
print("third", workflow.approximator.trainable_weights[0][0])
```

