### PR TITLE
Add wrapper around scipy.integrate.solve_ivp for integration

### DIFF
--- a/tests/test_utils/test_integrate.py
+++ b/tests/test_utils/test_integrate.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 def test_scheduled_integration():
     import keras
     from bayesflow.utils import integrate
@@ -9,3 +12,25 @@ def test_scheduled_integration():
     approximate_result = 0.0 + 0.5**2 * 0.5
     result = integrate(fn, {"x": 0.0}, steps=steps)["x"]
     assert result == approximate_result
+
+
+def test_scipy_integration():
+    import keras
+    from bayesflow.utils import integrate
+
+    def fn(t, x):
+        return {"x": keras.ops.exp(t)}
+
+    start_time = -1.0
+    stop_time = 1.0
+    exact_result = keras.ops.exp(stop_time) - keras.ops.exp(start_time)
+    result = integrate(
+        fn,
+        {"x": 0.0},
+        start_time=start_time,
+        stop_time=stop_time,
+        steps="adaptive",
+        method="scipy",
+        scipy_kwargs={"atol": 1e-6, "rtol": 1e-6},
+    )["x"]
+    np.testing.assert_allclose(exact_result, result, atol=1e-6, rtol=1e-6)


### PR DESCRIPTION
Closes #551. Here I propose to expose it via `method="scipy"`, if you have other ideas I'd be happy about suggestions regarding the interface. I use the adapter to achieve an invertible concatenation and the conversion of the data types.

Usage example for a workflow with a continuous normalizing flow:

```python
log_prob = workflow.log_prob(
    data, steps="adaptive", method="scipy", scipy_kwargs={"atol": 1e-6, "rtol": 1e-6}
)
```