### PR TITLE
Fix inconsistent type hints for `height` argument in `pairs_posterior()`

### DIFF
--- a/bayesflow/diagnostics/plots/pairs_posterior.py
+++ b/bayesflow/diagnostics/plots/pairs_posterior.py
@@ -1,7 +1,6 @@
-from collections.abc import Sequence, Mapping
+from collections.abc import Mapping, Sequence
 
 import matplotlib.pyplot as plt
-
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -18,7 +17,7 @@ def pairs_posterior(
     dataset_id: int = None,
     variable_keys: Sequence[str] = None,
     variable_names: Sequence[str] = None,
-    height: int = 3,
+    height: float = 3.0,
     post_color: str | tuple = "#132a70",
     prior_color: str | tuple = "gray",
     alpha: float = 0.9,


### PR DESCRIPTION
This PR fixes a type inconsistency for the `height` argument in `pairs_posterior()`.

### Problem
- The `height` parameter is type hinted as `int` in the function signature.  
- The docstring lists it as `float`.  
- The helper function `_pairs_samples()` assumes `float`.  
- This mismatch causes static type checkers (e.g., mypy, pyright) to raise errors.

### Solution
- Updated the type hint in `pairs_posterior()` to `float` for consistency with both the docstring and `_pairs_samples()`.  
- Ensures type checking tools behave correctly without requiring ignores.  

### Changes
- `pairs_posterior()` → `height: float`  
