### PR TITLE
Add New Flow Matching Schedules

### DIFF
--- a/bayesflow/networks/flow_matching/flow_matching.py
+++ b/bayesflow/networks/flow_matching/flow_matching.py
@@ -312,7 +312,7 @@ class FlowMatching(InferenceNetwork):
 
             u = keras.random.uniform((keras.ops.shape(x0)[0],), seed=self.seed_generator)
             # p(t) ∝ t^(1/(1+α)), the inverse CDF: F^(-1)(u) = u^(1+α), α=0 is uniform
-            t = u ** (1 + self.alpha)
+            t = u ** (1 + self.time_sampling_alpha)
             t = expand_right_as(t, x0)
 
             x = t * x1 + (1 - t) * x0

--- a/bayesflow/networks/flow_matching/flow_matching.py
+++ b/bayesflow/networks/flow_matching/flow_matching.py
@@ -59,6 +59,7 @@ class FlowMatching(InferenceNetwork):
         integrate_kwargs: dict[str, any] = None,
         optimal_transport_kwargs: dict[str, any] = None,
         subnet_kwargs: dict[str, any] = None,
+        time_power_law_alpha: float = 0.0,
         **kwargs,
     ):
         """
@@ -97,7 +98,7 @@ class FlowMatching(InferenceNetwork):
             must accept three separate inputs: 'x' (noisy parameters), 't' (time),
             and optional 'conditions'. Default is True.
         time_power_law_alpha: float, optional
-            Change the distribution of sampled times during training. Time is sampled from a power law distribution
+            Changes the distribution of sampled times during training. Time is sampled from a power law distribution
              p(t) ∝ t^(1/(1+α)), where α is the provided value. Default is α=0, which corresponds to uniform sampling.
         **kwargs
             Additional keyword arguments passed to the subnet and other components.
@@ -110,7 +111,7 @@ class FlowMatching(InferenceNetwork):
         self.optimal_transport_kwargs = FlowMatching.OPTIMAL_TRANSPORT_DEFAULT_CONFIG | (optimal_transport_kwargs or {})
 
         self.loss_fn = keras.losses.get(loss_fn)
-        self.time_power_law_alpha = float(kwargs.pop("time_power_law_alpha", 0.0))  # 0 is uniform, <0 favors smaller t
+        self.time_power_law_alpha = float(time_power_law_alpha)
         if self.time_power_law_alpha <= -1.0:
             raise ValueError("'time_power_law_alpha' must be greater than -1.0.")
 

--- a/bayesflow/networks/flow_matching/flow_matching.py
+++ b/bayesflow/networks/flow_matching/flow_matching.py
@@ -20,12 +20,19 @@ from ..inference_network import InferenceNetwork
 
 @serializable("bayesflow.networks")
 class FlowMatching(InferenceNetwork):
-    """(IN) Implements Optimal Transport Flow Matching, originally introduced as Rectified Flow, with ideas incorporated
-    from [1-3].
+    """(IN) Implements Optimal Transport Flow Matching, originally introduced as Rectified Flow, with ideas
+    incorporated from [1-5].
 
-    [1] Rectified Flow: arXiv:2209.03003
-    [2] Flow Matching: arXiv:2210.02747
-    [3] Optimal Transport Flow Matching: arXiv:2302.00482
+    [1] Liu et al. (2022). Flow straight and fast: Learning to generate and transfer data with rectified flow.
+        arXiv preprint arXiv:2209.03003.
+    [2] Lipman et al. (2022). Flow matching for generative modeling.
+        arXiv preprint arXiv:2210.02747.
+    [3] Tong et al. (2023). Improving and generalizing flow-based generative models with minibatch optimal transport.
+        arXiv preprint arXiv:2302.00482.
+    [4] Wildberger et al. (2023). Flow matching for scalable simulation-based inference.
+        Advances in Neural Information Processing Systems, 36, 16837-16864.
+    [5] Orsini et al. (2025). Flow matching posterior estimation for simulation-based atmospheric retrieval of
+        exoplanets. IEEE Access.
     """
 
     MLP_DEFAULT_CONFIG = {


### PR DESCRIPTION
Two papers in SBI context showed empirically that flow matching trained on a slightly different schedule for time improved performance. Instead of uniformly sampling t, they used a power law distribution.
[Flow Matching Posterior Estimation for Simulation-Based Atmospheric Retrieval of Exoplanets](https://ieeexplore.ieee.org/abstract/document/11106493)  
[Flow Matching for Scalable Simulation-Based Inference](https://arxiv.org/abs/2305.17161)


I added the option to flow matching to use this schedule and indeed it improves performance on two moons (512 batches, batch size 64, 50 epochs and standard settings in BayesFlow).

<img width="778" height="219" alt="output" src="https://github.com/user-attachments/assets/9bb6505d-0bcd-4c56-aa45-c5fc8cc8d90d" />

"pl" here refers to power law with alpha=-0.6, and "ot" to optimal transform