### PR TITLE
Enable Python 3.13 support, allow numpy 2.x

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.13"] # we usually only need to test the oldest python version
+        python-version: ["3.10"] # we usually only need to test the oldest python version
         backend: ["jax", "tensorflow", "torch"]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,3 @@
-
 name: Multi-Backend Tests
 
 on:
@@ -16,7 +15,6 @@ defaults:
   run:
     shell: bash
 
-
 jobs:
   test:
     name: Run Multi-Backend Tests
@@ -24,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10"]  # we usually only need to test the oldest python version
+        python-version: ["3.10", "3.13"] # we usually only need to test the oldest python version
         backend: ["jax", "tensorflow", "torch"]
 
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ complex to be described analytically.
 
 ## Install
 
-We currently support Python 3.10 to 3.12. You can install the latest stable version from PyPI using:
+We currently support Python 3.10 to 3.13. You can install the latest stable version from PyPI using:
 
 ```bash
 pip install "bayesflow>=2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,18 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 description = "Amortizing Bayesian Inference With Neural Networks"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE" }
 
-requires-python = ">= 3.10, < 3.13"
+requires-python = ">= 3.10, < 3.14"
 dependencies = [
     "keras >= 3.9",
     "matplotlib",
-    "numpy >= 1.24, <2.0",
+    "numpy >= 1.24",
     "pandas",
     "scipy",
     "seaborn",


### PR DESCRIPTION
TensorFlow has released a Python 3.13 compatible version, which was blocking us the last time we wanted to enable Python 3.13 support. Also, I have read the [NumPy 2.0 migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html), and there was nothing that stood out to me that would require action. With the test coverage we have now, I hope anything that could cause problems will show up in the tests.

I have adapted the test to run version 3.13, I will undo this when the tests have successfully passed.