### PR TITLE
Compositional sampling diffusion

### DIFF
--- a/bayesflow/approximators/continuous_approximator.py
+++ b/bayesflow/approximators/continuous_approximator.py
@@ -731,7 +731,7 @@ class ContinuousApproximator(Approximator):
         if inference_conditions is not None:
             # Reshape conditions for compositional sampling
             # From (n_datasets * n_comp, ...., dims) to (n_datasets, n_comp, ...., dims)
-            condition_dims = keras.ops.shape(inference_conditions)[2:]
+            condition_dims = keras.ops.shape(inference_conditions)[1:]
             inference_conditions = keras.ops.reshape(
                 inference_conditions, (n_datasets, n_compositional, *condition_dims)
             )

--- a/bayesflow/approximators/continuous_approximator.py
+++ b/bayesflow/approximators/continuous_approximator.py
@@ -535,7 +535,10 @@ class ContinuousApproximator(Approximator):
             inference_conditions = keras.ops.broadcast_to(
                 inference_conditions, (batch_size, num_samples, *keras.ops.shape(inference_conditions)[2:])
             )
-            batch_shape = keras.ops.shape(inference_conditions)[:-1]
+            batch_shape = (
+                batch_size,
+                num_samples,
+            )
         else:
             batch_shape = (num_samples,)
 

--- a/bayesflow/distributions/diagonal_normal.py
+++ b/bayesflow/distributions/diagonal_normal.py
@@ -91,7 +91,7 @@ class DiagonalNormal(Distribution):
         result = -0.5 * ops.sum((samples - self._mean) ** 2 / self._std**2, axis=-1)
 
         if normalize:
-            log_normalization_constant = -0.5 * ops.sum(self.dims) * math.log(2.0 * math.pi) - ops.sum(
+            log_normalization_constant = -0.5 * np.sum(self.dims) * math.log(2.0 * math.pi) - ops.sum(
                 ops.log(self._std)
             )
             result += log_normalization_constant

--- a/bayesflow/distributions/diagonal_normal.py
+++ b/bayesflow/distributions/diagonal_normal.py
@@ -57,7 +57,7 @@ class DiagonalNormal(Distribution):
         self.trainable_parameters = trainable_parameters
         self.seed_generator = seed_generator or keras.random.SeedGenerator()
 
-        self.dim = None
+        self.dims = None
         self._mean = None
         self._std = None
 
@@ -65,10 +65,10 @@ class DiagonalNormal(Distribution):
         if self.built:
             return
 
-        self.dim = int(input_shape[-1])
+        self.dims = input_shape[1:]
 
-        self.mean = ops.cast(ops.broadcast_to(self.mean, (self.dim,)), "float32")
-        self.std = ops.cast(ops.broadcast_to(self.std, (self.dim,)), "float32")
+        self.mean = ops.cast(ops.broadcast_to(self.mean, self.dims), "float32")
+        self.std = ops.cast(ops.broadcast_to(self.std, self.dims), "float32")
 
         if self.trainable_parameters:
             self._mean = self.add_weight(
@@ -91,14 +91,16 @@ class DiagonalNormal(Distribution):
         result = -0.5 * ops.sum((samples - self._mean) ** 2 / self._std**2, axis=-1)
 
         if normalize:
-            log_normalization_constant = -0.5 * self.dim * math.log(2.0 * math.pi) - ops.sum(ops.log(self._std))
+            log_normalization_constant = -0.5 * ops.sum(self.dims) * math.log(2.0 * math.pi) - ops.sum(
+                ops.log(self._std)
+            )
             result += log_normalization_constant
 
         return result
 
     @allow_batch_size
     def sample(self, batch_shape: Shape) -> Tensor:
-        return self._mean + self._std * keras.random.normal(shape=batch_shape + (self.dim,), seed=self.seed_generator)
+        return self._mean + self._std * keras.random.normal(shape=batch_shape + self.dims, seed=self.seed_generator)
 
     def get_config(self):
         base_config = super().get_config()

--- a/bayesflow/distributions/diagonal_normal.py
+++ b/bayesflow/distributions/diagonal_normal.py
@@ -65,7 +65,7 @@ class DiagonalNormal(Distribution):
         if self.built:
             return
 
-        self.dims = input_shape[1:]
+        self.dims = tuple(input_shape[1:])
 
         self.mean = ops.cast(ops.broadcast_to(self.mean, self.dims), "float32")
         self.std = ops.cast(ops.broadcast_to(self.std, self.dims), "float32")
@@ -91,9 +91,7 @@ class DiagonalNormal(Distribution):
         result = -0.5 * ops.sum((samples - self._mean) ** 2 / self._std**2, axis=-1)
 
         if normalize:
-            log_normalization_constant = -0.5 * np.sum(self.dims) * math.log(2.0 * math.pi) - ops.sum(
-                ops.log(self._std)
-            )
+            log_normalization_constant = -0.5 * sum(self.dims) * math.log(2.0 * math.pi) - ops.sum(ops.log(self._std))
             result += log_normalization_constant
 
         return result

--- a/bayesflow/networks/diffusion_model/diffusion_model.py
+++ b/bayesflow/networks/diffusion_model/diffusion_model.py
@@ -619,7 +619,6 @@ class DiffusionModel(InferenceNetwork):
             # ODE: dz = [f(z,t) - 0.5 * g(t)² * score(z,t)] dt
             velocity = f - 0.5 * g_squared * compositional_score
 
-        print(velocity.shape, velocity)
         return velocity
 
     def _compute_individual_scores(
@@ -684,7 +683,7 @@ class DiffusionModel(InferenceNetwork):
         score = (alpha_flat * x_pred - xz_flat) / ops.square(sigma_flat)
 
         # Reshape back to compositional structure
-        score = ops.reshape(score, (n_datasets, n_compositional, num_samples))
+        score = ops.reshape(score, (n_datasets, n_compositional, num_samples) + dims)
         return score
 
     def _forward_compositional(

--- a/bayesflow/networks/diffusion_model/diffusion_model.py
+++ b/bayesflow/networks/diffusion_model/diffusion_model.py
@@ -583,7 +583,7 @@ class DiffusionModel(InferenceNetwork):
 
         # Calculate standard noise schedule components
         log_snr_t = expand_right_as(self.noise_schedule.get_log_snr(t=time, training=training), xz)
-        log_snr_t = ops.broadcast_to(log_snr_t, ops.shape(xz)[:1] + (1,))
+        log_snr_t = ops.broadcast_to(log_snr_t, ops.shape(xz)[:-1] + (1,))
         alpha_t, sigma_t = self.noise_schedule.get_alpha_sigma(log_snr_t=log_snr_t)
 
         # Compute individual dataset scores

--- a/bayesflow/networks/diffusion_model/diffusion_model.py
+++ b/bayesflow/networks/diffusion_model/diffusion_model.py
@@ -725,17 +725,18 @@ class DiffusionModel(InferenceNetwork):
         scale_latent = n_compositional * self.compositional_bridge(ops.ones(1))
         z = z / ops.sqrt(ops.cast(scale_latent, dtype=ops.dtype(z)))
 
-        if mini_batch_size is not None and mini_batch_size < n_compositional:
-            # sample random indices for mini-batch processing
-            mini_batch_idx = keras.random.shuffle(ops.arange(n_compositional), seed=self.seed_generator)
-        else:
-            mini_batch_idx = None
-
         if density:
             if integrate_kwargs["method"] == "euler_maruyama":
                 raise ValueError("Stochastic methods are not supported for density computation.")
 
             def deltas(time, xz):
+                if mini_batch_size is not None and mini_batch_size < n_compositional:
+                    # sample random indices for mini-batch processing
+                    mini_batch_idx = keras.random.shuffle(ops.arange(n_compositional), seed=self.seed_generator)
+                    mini_batch_idx = mini_batch_idx[:mini_batch_size]
+                else:
+                    mini_batch_idx = None
+
                 v = self.compositional_velocity(
                     xz,
                     time=time,
@@ -762,6 +763,13 @@ class DiffusionModel(InferenceNetwork):
         if integrate_kwargs["method"] == "euler_maruyama":
 
             def deltas(time, xz):
+                if mini_batch_size is not None and mini_batch_size < n_compositional:
+                    # sample random indices for mini-batch processing
+                    mini_batch_idx = keras.random.shuffle(ops.arange(n_compositional), seed=self.seed_generator)
+                    mini_batch_idx = mini_batch_idx[:mini_batch_size]
+                else:
+                    mini_batch_idx = None
+
                 return {
                     "xz": self.compositional_velocity(
                         xz,
@@ -786,6 +794,13 @@ class DiffusionModel(InferenceNetwork):
         else:
 
             def deltas(time, xz):
+                if mini_batch_size is not None and mini_batch_size < n_compositional:
+                    # sample random indices for mini-batch processing
+                    mini_batch_idx = keras.random.shuffle(ops.arange(n_compositional), seed=self.seed_generator)
+                    mini_batch_idx = mini_batch_idx[:mini_batch_size]
+                else:
+                    mini_batch_idx = None
+
                 return {
                     "xz": self.compositional_velocity(
                         xz,

--- a/bayesflow/networks/diffusion_model/diffusion_model.py
+++ b/bayesflow/networks/diffusion_model/diffusion_model.py
@@ -583,10 +583,12 @@ class DiffusionModel(InferenceNetwork):
 
         # Calculate standard noise schedule components
         log_snr_t = expand_right_as(self.noise_schedule.get_log_snr(t=time, training=training), xz)
-        log_snr_t = ops.broadcast_to(log_snr_t, ops.shape(xz)[:-1] + (1,))
+        log_snr_t = ops.broadcast_to(log_snr_t, ops.shape(xz)[:1] + (1,))
         alpha_t, sigma_t = self.noise_schedule.get_alpha_sigma(log_snr_t=log_snr_t)
 
         # Compute individual dataset scores
+        print(xz.shape, log_snr_t.shape, alpha_t.shape, sigma_t.shape, conditions.shape)
+        # (1, 100, 2) (1, 100, 1) (1, 100, 1) (1, 100, 1) (1, 2, 100, 2)
         individual_scores = self._compute_individual_scores(xz, log_snr_t, alpha_t, sigma_t, conditions, training)
 
         # Compute prior score component
@@ -643,18 +645,34 @@ class DiffusionModel(InferenceNetwork):
         # Apply subnet to each compositional condition separately
         transformed_log_snr = self._transform_log_snr(log_snr_t)
 
-        # Reshape for processing: flatten compositional dimension temporarily
-        original_shape = ops.shape(conditions)
-        n_datasets, n_comp = original_shape[0], original_shape[1]
+        # Get shapes
+        xz_shape = ops.shape(xz)  # (n_datasets, num_samples, ..., dims)
+        conditions_shape = ops.shape(conditions)  # (n_datasets, n_compositional, num_samples, ..., dims)
+        n_datasets, n_compositional = conditions_shape[0], conditions_shape[1]
+        conditions_dims = tuple(conditions_shape[3:])
+        num_samples = xz_shape[1]
+        dims = tuple(xz_shape[2:])
 
-        # Flatten for subnet application
-        xz_flat = ops.expand_dims(xz, axis=1)  # (n_datasets, 1, ...)
-        xz_flat = ops.broadcast_to(xz_flat, (n_datasets, n_comp) + ops.shape(xz)[1:])
-        xz_flat = ops.reshape(xz_flat, (n_datasets * n_comp,) + ops.shape(xz)[1:])
-        log_snr_flat = ops.reshape(transformed_log_snr, (n_datasets * n_comp,) + ops.shape(transformed_log_snr)[2:])
-        conditions_flat = ops.reshape(conditions, (n_datasets * n_comp,) + ops.shape(conditions)[2:])
-        alpha_flat = ops.reshape(alpha_t, (n_datasets * n_comp,) + ops.shape(alpha_t)[2:])
-        sigma_flat = ops.reshape(sigma_t, (n_datasets * n_comp,) + ops.shape(sigma_t)[2:])
+        # Expand xz to match compositional structure
+        xz_expanded = ops.expand_dims(xz, axis=1)  # (n_datasets, 1, num_samples, ..., dims)
+        xz_expanded = ops.broadcast_to(xz_expanded, (n_datasets, n_compositional, num_samples) + dims)
+
+        # Expand noise schedule components to match compositional structure
+        log_snr_expanded = ops.expand_dims(transformed_log_snr, axis=1)
+        log_snr_expanded = ops.broadcast_to(log_snr_expanded, (n_datasets, n_compositional, num_samples) + dims)
+
+        alpha_expanded = ops.expand_dims(alpha_t, axis=1)
+        alpha_expanded = ops.broadcast_to(alpha_expanded, (n_datasets, n_compositional, num_samples) + dims)
+
+        sigma_expanded = ops.expand_dims(sigma_t, axis=1)
+        sigma_expanded = ops.broadcast_to(sigma_expanded, (n_datasets, n_compositional, num_samples) + dims)
+
+        # Flatten for subnet application: (n_datasets * n_compositional, num_samples, ..., dims)
+        xz_flat = ops.reshape(xz_expanded, (n_datasets * n_compositional, num_samples) + dims)
+        log_snr_flat = ops.reshape(log_snr_expanded, (n_datasets * n_compositional, num_samples) + dims)
+        alpha_flat = ops.reshape(alpha_expanded, (n_datasets * n_compositional, num_samples) + dims)
+        sigma_flat = ops.reshape(sigma_expanded, (n_datasets * n_compositional, num_samples) + dims)
+        conditions_flat = ops.reshape(conditions, (n_datasets * n_compositional, num_samples) + conditions_dims)
 
         # Apply subnet
         subnet_out = self._apply_subnet(xz_flat, log_snr_flat, conditions=conditions_flat, training=training)
@@ -669,8 +687,7 @@ class DiffusionModel(InferenceNetwork):
         score = (alpha_flat * x_pred - xz_flat) / ops.square(sigma_flat)
 
         # Reshape back to compositional structure
-        score = ops.reshape(score, original_shape)
-
+        score = ops.reshape(score, (n_datasets, n_compositional, num_samples))
         return score
 
     def _forward_compositional(

--- a/bayesflow/networks/diffusion_model/diffusion_model.py
+++ b/bayesflow/networks/diffusion_model/diffusion_model.py
@@ -598,7 +598,7 @@ class DiffusionModel(InferenceNetwork):
         time_tensor = ops.cast(time, dtype=ops.dtype(xz))
 
         # Sum individual scores across compositional dimension
-        summed_individual_scores = ops.sum(individual_scores, axis=1, keepdims=True)
+        summed_individual_scores = ops.sum(individual_scores, axis=1)
 
         # Prior contribution: (1-n)(1-t) * prior_score
         prior_weight = (1.0 - n) * (1.0 - time_tensor)
@@ -608,7 +608,7 @@ class DiffusionModel(InferenceNetwork):
         compositional_score = weighted_prior + summed_individual_scores
 
         # Broadcast back to full compositional shape
-        compositional_score = ops.broadcast_to(compositional_score, ops.shape(xz))
+        # compositional_score = ops.broadcast_to(compositional_score, ops.shape(xz))
 
         # Compute velocity using standard drift-diffusion formulation
         f, g_squared = self.noise_schedule.get_drift_diffusion(log_snr_t=log_snr_t, x=xz, training=training)

--- a/bayesflow/networks/diffusion_model/diffusion_model.py
+++ b/bayesflow/networks/diffusion_model/diffusion_model.py
@@ -578,8 +578,8 @@ class DiffusionModel(InferenceNetwork):
             raise ValueError("Conditions are required for compositional sampling")
 
         # Get shapes for compositional structure
-        n_datasets, n_compositional = ops.shape(xz)[0], ops.shape(xz)[1]
-        print(xz.shape, n_datasets, n_compositional)
+        n_compositional = ops.shape(conditions)[1]
+        print(ops.shape(xz), ops.shape(conditions))
 
         # Calculate standard noise schedule components
         log_snr_t = expand_right_as(self.noise_schedule.get_log_snr(t=time, training=training), xz)
@@ -620,7 +620,7 @@ class DiffusionModel(InferenceNetwork):
             # ODE: dz = [f(z,t) - 0.5 * g(t)² * score(z,t)] dt
             velocity = f - 0.5 * g_squared * compositional_score
 
-        print(velocity.shape)
+        print(velocity.shape, velocity)
         return velocity
 
     def _compute_individual_scores(

--- a/bayesflow/networks/diffusion_model/diffusion_model.py
+++ b/bayesflow/networks/diffusion_model/diffusion_model.py
@@ -579,7 +579,6 @@ class DiffusionModel(InferenceNetwork):
 
         # Get shapes for compositional structure
         n_compositional = ops.shape(conditions)[1]
-        print(ops.shape(xz), ops.shape(conditions))  # (1, 100, 2), (1, 2, 100, 2)
 
         # Calculate standard noise schedule components
         log_snr_t = expand_right_as(self.noise_schedule.get_log_snr(t=time, training=training), xz)
@@ -587,8 +586,6 @@ class DiffusionModel(InferenceNetwork):
         alpha_t, sigma_t = self.noise_schedule.get_alpha_sigma(log_snr_t=log_snr_t)
 
         # Compute individual dataset scores
-        print(xz.shape, log_snr_t.shape, alpha_t.shape, sigma_t.shape, conditions.shape)
-        # (1, 100, 2) (1, 100, 1) (1, 100, 1) (1, 100, 1) (1, 2, 100, 2)
         individual_scores = self._compute_individual_scores(xz, log_snr_t, alpha_t, sigma_t, conditions, training)
 
         # Compute prior score component
@@ -659,19 +656,19 @@ class DiffusionModel(InferenceNetwork):
 
         # Expand noise schedule components to match compositional structure
         log_snr_expanded = ops.expand_dims(transformed_log_snr, axis=1)
-        log_snr_expanded = ops.broadcast_to(log_snr_expanded, (n_datasets, n_compositional, num_samples) + dims)
+        log_snr_expanded = ops.broadcast_to(log_snr_expanded, (n_datasets, n_compositional, num_samples, 1))
 
         alpha_expanded = ops.expand_dims(alpha_t, axis=1)
-        alpha_expanded = ops.broadcast_to(alpha_expanded, (n_datasets, n_compositional, num_samples) + dims)
+        alpha_expanded = ops.broadcast_to(alpha_expanded, (n_datasets, n_compositional, num_samples, 1))
 
         sigma_expanded = ops.expand_dims(sigma_t, axis=1)
-        sigma_expanded = ops.broadcast_to(sigma_expanded, (n_datasets, n_compositional, num_samples) + dims)
+        sigma_expanded = ops.broadcast_to(sigma_expanded, (n_datasets, n_compositional, num_samples, 1))
 
         # Flatten for subnet application: (n_datasets * n_compositional, num_samples, ..., dims)
         xz_flat = ops.reshape(xz_expanded, (n_datasets * n_compositional, num_samples) + dims)
-        log_snr_flat = ops.reshape(log_snr_expanded, (n_datasets * n_compositional, num_samples) + dims)
-        alpha_flat = ops.reshape(alpha_expanded, (n_datasets * n_compositional, num_samples) + dims)
-        sigma_flat = ops.reshape(sigma_expanded, (n_datasets * n_compositional, num_samples) + dims)
+        log_snr_flat = ops.reshape(log_snr_expanded, (n_datasets * n_compositional, num_samples, 1))
+        alpha_flat = ops.reshape(alpha_expanded, (n_datasets * n_compositional, num_samples, 1))
+        sigma_flat = ops.reshape(sigma_expanded, (n_datasets * n_compositional, num_samples, 1))
         conditions_flat = ops.reshape(conditions, (n_datasets * n_compositional, num_samples) + conditions_dims)
 
         # Apply subnet

--- a/bayesflow/networks/diffusion_model/diffusion_model.py
+++ b/bayesflow/networks/diffusion_model/diffusion_model.py
@@ -672,7 +672,7 @@ class DiffusionModel(InferenceNetwork):
 
         return score
 
-    def _compositional_forward(
+    def _forward_compositional(
         self,
         x: Tensor,
         conditions: Tensor = None,
@@ -727,7 +727,7 @@ class DiffusionModel(InferenceNetwork):
         z = state["xz"]
         return z
 
-    def _compositional_inverse(
+    def _inverse_compositional(
         self,
         z: Tensor,
         conditions: Tensor = None,

--- a/bayesflow/networks/inference_network.py
+++ b/bayesflow/networks/inference_network.py
@@ -1,3 +1,4 @@
+from typing import Callable
 import keras
 
 from bayesflow.types import Shape, Tensor
@@ -52,12 +53,24 @@ class InferenceNetwork(keras.Layer):
         raise NotImplementedError
 
     def _forward_compositional(
-        self, x: Tensor, conditions: Tensor = None, density: bool = False, training: bool = False, **kwargs
+        self,
+        x: Tensor,
+        conditions: Tensor,
+        compute_prior_score: Callable[[Tensor], Tensor],
+        density: bool = False,
+        training: bool = False,
+        **kwargs,
     ) -> Tensor | tuple[Tensor, Tensor]:
         raise NotImplementedError
 
     def _inverse_compositional(
-        self, z: Tensor, conditions: Tensor = None, density: bool = False, training: bool = False, **kwargs
+        self,
+        z: Tensor,
+        conditions: Tensor,
+        compute_prior_score: Callable[[Tensor], Tensor],
+        density: bool = False,
+        training: bool = False,
+        **kwargs,
     ) -> Tensor | tuple[Tensor, Tensor]:
         raise NotImplementedError
 

--- a/bayesflow/networks/inference_network.py
+++ b/bayesflow/networks/inference_network.py
@@ -35,16 +35,14 @@ class InferenceNetwork(keras.Layer):
         if inverse:
             if compute_prior_score is not None:
                 return self._inverse_compositional(
-                    xz, conditions=conditions, density=density, training=training, **kwargs
+                    xz,
+                    conditions=conditions,
+                    compute_prior_score=compute_prior_score,
+                    density=density,
+                    training=training,
+                    **kwargs,
                 )
-            return self._inverse(
-                xz,
-                conditions=conditions,
-                compute_prior_score=compute_prior_score,
-                density=density,
-                training=training,
-                **kwargs,
-            )
+            return self._inverse(xz, conditions=conditions, density=density, training=training, **kwargs)
         if compute_prior_score is not None:
             return self._forward_compositional(
                 xz,

--- a/bayesflow/networks/inference_network.py
+++ b/bayesflow/networks/inference_network.py
@@ -28,18 +28,32 @@ class InferenceNetwork(keras.Layer):
         conditions: Tensor = None,
         inverse: bool = False,
         density: bool = False,
-        compositional: bool = False,
+        compute_prior_score: Callable[[Tensor], Tensor] = None,
         training: bool = False,
         **kwargs,
     ) -> Tensor | tuple[Tensor, Tensor]:
         if inverse:
-            if compositional:
+            if compute_prior_score is not None:
                 return self._inverse_compositional(
                     xz, conditions=conditions, density=density, training=training, **kwargs
                 )
-            return self._inverse(xz, conditions=conditions, density=density, training=training, **kwargs)
-        if compositional:
-            return self._forward_compositional(xz, conditions=conditions, density=density, training=training, **kwargs)
+            return self._inverse(
+                xz,
+                conditions=conditions,
+                compute_prior_score=compute_prior_score,
+                density=density,
+                training=training,
+                **kwargs,
+            )
+        if compute_prior_score is not None:
+            return self._forward_compositional(
+                xz,
+                conditions=conditions,
+                compute_prior_score=compute_prior_score,
+                density=density,
+                training=training,
+                **kwargs,
+            )
         return self._forward(xz, conditions=conditions, density=density, training=training, **kwargs)
 
     def _forward(

--- a/bayesflow/networks/inference_network.py
+++ b/bayesflow/networks/inference_network.py
@@ -27,11 +27,18 @@ class InferenceNetwork(keras.Layer):
         conditions: Tensor = None,
         inverse: bool = False,
         density: bool = False,
+        compositional: bool = False,
         training: bool = False,
         **kwargs,
     ) -> Tensor | tuple[Tensor, Tensor]:
         if inverse:
+            if compositional:
+                return self._inverse_compositional(
+                    xz, conditions=conditions, density=density, training=training, **kwargs
+                )
             return self._inverse(xz, conditions=conditions, density=density, training=training, **kwargs)
+        if compositional:
+            return self._forward_compositional(xz, conditions=conditions, density=density, training=training, **kwargs)
         return self._forward(xz, conditions=conditions, density=density, training=training, **kwargs)
 
     def _forward(
@@ -40,6 +47,16 @@ class InferenceNetwork(keras.Layer):
         raise NotImplementedError
 
     def _inverse(
+        self, z: Tensor, conditions: Tensor = None, density: bool = False, training: bool = False, **kwargs
+    ) -> Tensor | tuple[Tensor, Tensor]:
+        raise NotImplementedError
+
+    def _forward_compositional(
+        self, x: Tensor, conditions: Tensor = None, density: bool = False, training: bool = False, **kwargs
+    ) -> Tensor | tuple[Tensor, Tensor]:
+        raise NotImplementedError
+
+    def _inverse_compositional(
         self, z: Tensor, conditions: Tensor = None, density: bool = False, training: bool = False, **kwargs
     ) -> Tensor | tuple[Tensor, Tensor]:
         raise NotImplementedError

--- a/bayesflow/workflows/basic_workflow.py
+++ b/bayesflow/workflows/basic_workflow.py
@@ -291,7 +291,7 @@ class BasicWorkflow(Workflow):
         *,
         num_samples: int,
         conditions: Mapping[str, np.ndarray],
-        prior_score: Callable[[Mapping[str, np.ndarray]], np.ndarray],
+        compute_prior_score: Callable[[Mapping[str, np.ndarray]], np.ndarray],
         **kwargs,
     ) -> dict[str, np.ndarray]:
         """
@@ -307,7 +307,7 @@ class BasicWorkflow(Workflow):
             NumPy arrays containing the adapted simulated variables. Keys used as summary or inference
             conditions during training should be present.
             Should have shape (n_datasets, n_compositional_conditions, ...).
-        prior_score : Callable[[Mapping[str, np.ndarray]], np.ndarray]
+        compute_prior_score : Callable[[Mapping[str, np.ndarray]], np.ndarray]
             A function that computes the log probability of samples under the prior distribution.
         **kwargs : dict, optional
             Additional keyword arguments passed to the approximator's sampling function.
@@ -319,7 +319,7 @@ class BasicWorkflow(Workflow):
             values are arrays containing the generated samples.
         """
         return self.approximator.compositional_sample(
-            num_samples=num_samples, conditions=conditions, prior_score=prior_score, **kwargs
+            num_samples=num_samples, conditions=conditions, compute_prior_score=compute_prior_score, **kwargs
         )
 
     def estimate(

--- a/bayesflow/workflows/basic_workflow.py
+++ b/bayesflow/workflows/basic_workflow.py
@@ -291,6 +291,7 @@ class BasicWorkflow(Workflow):
         *,
         num_samples: int,
         conditions: Mapping[str, np.ndarray],
+        prior_score: Callable[[Mapping[str, np.ndarray]], np.ndarray],
         **kwargs,
     ) -> dict[str, np.ndarray]:
         """
@@ -306,6 +307,8 @@ class BasicWorkflow(Workflow):
             NumPy arrays containing the adapted simulated variables. Keys used as summary or inference
             conditions during training should be present.
             Should have shape (n_datasets, n_compositional_conditions, ...).
+        prior_score : Callable[[Mapping[str, np.ndarray]], np.ndarray]
+            A function that computes the log probability of samples under the prior distribution.
         **kwargs : dict, optional
             Additional keyword arguments passed to the approximator's sampling function.
 
@@ -315,7 +318,9 @@ class BasicWorkflow(Workflow):
             A dictionary where keys correspond to variable names and
             values are arrays containing the generated samples.
         """
-        return self.approximator.compositional_sample(num_samples=num_samples, conditions=conditions, **kwargs)
+        return self.approximator.compositional_sample(
+            num_samples=num_samples, conditions=conditions, prior_score=prior_score, **kwargs
+        )
 
     def estimate(
         self,

--- a/bayesflow/workflows/basic_workflow.py
+++ b/bayesflow/workflows/basic_workflow.py
@@ -286,6 +286,37 @@ class BasicWorkflow(Workflow):
         """
         return self.approximator.sample(num_samples=num_samples, conditions=conditions, **kwargs)
 
+    def compositional_sample(
+        self,
+        *,
+        num_samples: int,
+        conditions: Mapping[str, np.ndarray],
+        **kwargs,
+    ) -> dict[str, np.ndarray]:
+        """
+        Draws `num_samples` samples from the approximator given specified composition conditions.
+        The `conditions` dictionary should have shape (n_datasets, n_compositional_conditions, ...).
+
+        Parameters
+        ----------
+        num_samples : int
+            The number of samples to generate.
+        conditions : dict[str, np.ndarray]
+            A dictionary where keys represent variable names and values are
+            NumPy arrays containing the adapted simulated variables. Keys used as summary or inference
+            conditions during training should be present.
+            Should have shape (n_datasets, n_compositional_conditions, ...).
+        **kwargs : dict, optional
+            Additional keyword arguments passed to the approximator's sampling function.
+
+        Returns
+        -------
+        dict[str, np.ndarray]
+            A dictionary where keys correspond to variable names and
+            values are arrays containing the generated samples.
+        """
+        return self.approximator.compositional_sample(num_samples=num_samples, conditions=conditions, **kwargs)
+
     def estimate(
         self,
         *,


### PR DESCRIPTION
This pull request introduces compositional sampling support to the BayesFlow framework, enabling diffusion models to handle multiple compositional conditions efficiently. The main changes span the continuous approximator, diffusion model, and inference network modules, adding new methods and refactoring existing ones to support compositional structures in sampling, inference, and diffusion processes.

Larger changes include:
* Added a new `compositional_sample` method to `ContinuousApproximator`, which generates samples with compositional structure and handles flattening, reshaping, and prior score computation for multiple compositional conditions. Supporting internal method `_compositional_sample` was also introduced.
* In `DiffusionModel`, implemented compositional diffusion support including:
  - New `compositional_bridge` and `compositional_velocity` methods for compositional score calculation.
  - `_compute_individual_scores` helper for handling multiple compositional conditions.
  - `_inverse_compositional` method for inverse compositional diffusion sampling.
  
 
The idea is that the workflow now has the method `compositional_sample`, which expects conditions in the form (n_datasets, n_conditions, ...). Then we can perform compositional sampling with diffusion models.
`compositional_sample` allows to set a `mini_batch_size` for memory efficient computation of the compositional score, which does not work with `jax` backend however, as `jax` does not like stochasticity in its integrators which cannot be precomputed. We could support here only fixed step sizes though?

To compute the compositional score we need access to the score of the prior. Here we need to handle the adapter carefully so that we compute the correct score. In the current draft, I was not able to compute the prior score correctly. Some ideas would be great, currently it fails because the adpater is converting stuff to numpy back and forth.