### PR TITLE
Fix: Add missing standardization calls to Approximator.summarize

### DIFF
--- a/bayesflow/approximators/continuous_approximator.py
+++ b/bayesflow/approximators/continuous_approximator.py
@@ -570,11 +570,11 @@ class ContinuousApproximator(Approximator):
         if self.summary_network is None:
             raise ValueError("A summary network is required to compute summaries.")
 
-        data_adapted = self.adapter(data, strict=False, **kwargs)
+        data_adapted = self._prepare_data(data, **kwargs)
         if "summary_variables" not in data_adapted or data_adapted["summary_variables"] is None:
             raise ValueError("Summary variables are required to compute summaries.")
 
-        summary_variables = keras.tree.map_structure(keras.ops.convert_to_tensor, data_adapted["summary_variables"])
+        summary_variables = data_adapted["summary_variables"]
         summaries = self.summary_network(summary_variables, **filter_kwargs(kwargs, self.summary_network.call))
         summaries = keras.ops.convert_to_numpy(summaries)
 

--- a/bayesflow/approximators/model_comparison_approximator.py
+++ b/bayesflow/approximators/model_comparison_approximator.py
@@ -433,6 +433,10 @@ class ModelComparisonApproximator(Approximator):
             raise ValueError("Summary variables are required to compute summaries.")
 
         summary_variables = keras.tree.map_structure(keras.ops.convert_to_tensor, data_adapted["summary_variables"])
+
+        if "summary_variables" in self.standardize:
+            summary_variables = self.standardize_layers["summary_variables"](summary_variables)
+
         summaries = self.summary_network(summary_variables, **filter_kwargs(kwargs, self.summary_network.call))
         summaries = keras.ops.convert_to_numpy(summaries)
 


### PR DESCRIPTION
This PR fixes #580 by adding the required calls to standardize `summary_variables`. For the `ContinuousApproximator`, it takes advantage of the existing `_prepare_data` method.