### PR TITLE
Fix ratio approximator bug when batch size is smaller than num contrastive samples

### DIFF
--- a/bayesflow/approximators/ratio_approximator.py
+++ b/bayesflow/approximators/ratio_approximator.py
@@ -139,19 +139,19 @@ class RatioApproximator(Approximator):
         batch_size = keras.ops.shape(inference_variables)[0]
 
         log_gamma = keras.ops.broadcast_to(keras.ops.log(self.gamma), (batch_size,))
+        log_K = keras.ops.broadcast_to(keras.ops.log(self.K), (batch_size,))
+
         marginal_weight = 1 / (1 + self.gamma)
         joint_weight = self.gamma / (1 + self.gamma)
 
         # Get (batch_size, K+1, dim) inference variables (theta)
         bootstrap_inference_variables = self._sample_from_batch(inference_variables)
-        num_contrastive = keras.ops.shape(bootstrap_inference_variables)[1]
-        log_K = keras.ops.broadcast_to(keras.ops.log(num_contrastive), (batch_size,))
         bootstrap_inference_variables = keras.ops.concatenate(
             [inference_variables[:, None, :], bootstrap_inference_variables], axis=1
         )
 
         # Get (batch_size, K, dim) conditions (already resolved from condition builder)
-        conditions = expand_tile(resolved_conditions, n=num_contrastive, axis=1)
+        conditions = expand_tile(resolved_conditions, n=self.K, axis=1)
 
         marginal_logits = self.logits(
             bootstrap_inference_variables[:, 1:, :], conditions, stage=stage, **inference_kwargs
@@ -274,13 +274,9 @@ class RatioApproximator(Approximator):
 
     def _sample_from_batch(self, inference_variables: Tensor) -> Tensor:
         B = keras.ops.shape(inference_variables)[0]
+        num_contrastive = min(self.K, B - 1)
 
-        if isinstance(B, int) and self.K > B - 1:
-            num_contrastive = B - 1
-        else:
-            num_contrastive = self.K
-
-        # Sample from (B, B-1) space — O(B*K) instead of O(B^2)
+        # Sample from (B, B-1) space in O(B*K) instead of O(B^2)
         scores = keras.random.uniform(
             shape=(B, B - 1),
             dtype="float32",

--- a/bayesflow/approximators/ratio_approximator.py
+++ b/bayesflow/approximators/ratio_approximator.py
@@ -145,6 +145,7 @@ class RatioApproximator(Approximator):
         # Get (batch_size, K+1, dim) inference variables (theta)
         bootstrap_inference_variables = self._sample_from_batch(inference_variables)
         num_contrastive = keras.ops.shape(bootstrap_inference_variables)[1]
+
         log_K = keras.ops.broadcast_to(keras.ops.log(num_contrastive), (batch_size,))
         bootstrap_inference_variables = keras.ops.concatenate(
             [inference_variables[:, None, :], bootstrap_inference_variables], axis=1
@@ -274,7 +275,7 @@ class RatioApproximator(Approximator):
 
     def _sample_from_batch(self, inference_variables: Tensor) -> Tensor:
         B = keras.ops.shape(inference_variables)[0]
-        num_contrastive = keras.ops.minimum(self.K, B - 1)
+        num_contrastive = min(self.K, B - 1) if isinstance(B, int) else keras.ops.minimum(self.K, B - 1)
 
         # Sample from (B, B-1) space in O(B*K) instead of O(B^2)
         scores = keras.random.uniform(

--- a/bayesflow/approximators/ratio_approximator.py
+++ b/bayesflow/approximators/ratio_approximator.py
@@ -139,19 +139,19 @@ class RatioApproximator(Approximator):
         batch_size = keras.ops.shape(inference_variables)[0]
 
         log_gamma = keras.ops.broadcast_to(keras.ops.log(self.gamma), (batch_size,))
-        log_K = keras.ops.broadcast_to(keras.ops.log(self.K), (batch_size,))
-
         marginal_weight = 1 / (1 + self.gamma)
         joint_weight = self.gamma / (1 + self.gamma)
 
         # Get (batch_size, K+1, dim) inference variables (theta)
         bootstrap_inference_variables = self._sample_from_batch(inference_variables)
+        num_contrastive = keras.ops.shape(bootstrap_inference_variables)[1]
+        log_K = keras.ops.broadcast_to(keras.ops.log(num_contrastive), (batch_size,))
         bootstrap_inference_variables = keras.ops.concatenate(
             [inference_variables[:, None, :], bootstrap_inference_variables], axis=1
         )
 
         # Get (batch_size, K, dim) conditions (already resolved from condition builder)
-        conditions = expand_tile(resolved_conditions, n=self.K, axis=1)
+        conditions = expand_tile(resolved_conditions, n=num_contrastive, axis=1)
 
         marginal_logits = self.logits(
             bootstrap_inference_variables[:, 1:, :], conditions, stage=stage, **inference_kwargs

--- a/bayesflow/approximators/ratio_approximator.py
+++ b/bayesflow/approximators/ratio_approximator.py
@@ -274,7 +274,7 @@ class RatioApproximator(Approximator):
 
     def _sample_from_batch(self, inference_variables: Tensor) -> Tensor:
         B = keras.ops.shape(inference_variables)[0]
-        num_contrastive = min(self.K, B - 1)
+        num_contrastive = keras.ops.minimum(self.K, B - 1)
 
         # Sample from (B, B-1) space in O(B*K) instead of O(B^2)
         scores = keras.random.uniform(
@@ -285,7 +285,7 @@ class RatioApproximator(Approximator):
         _, idx = keras.ops.top_k(scores, k=num_contrastive)
 
         # Remap indices >= row index to skip self: [0..i-1] unchanged, [i..B-2] -> [i+1..B-1]
-        row = keras.ops.arange(B)[:, None]  # (B, 1)
+        row = keras.ops.arange(B)[:, None]
         idx = idx + keras.ops.cast(idx >= row, dtype=idx.dtype)
 
         return keras.ops.take(inference_variables, idx, axis=0)

--- a/tests/test_approximators/test_ratio_approximator/test_ratio_approximator.py
+++ b/tests/test_approximators/test_ratio_approximator/test_ratio_approximator.py
@@ -51,6 +51,15 @@ def test_contrastive_sampling(adapter, simulator, approximator):
         assert not keras.ops.all(keras.ops.isclose(iv, civ[:, k]))
 
 
+def test_compute_metrics_with_fewer_samples_than_k(adapter, simulator, approximator):
+    batch = adapter(simulator.sample(approximator.K - 1))
+    approximator.build_from_data(batch)
+
+    metrics = approximator.compute_metrics(**batch)
+
+    assert keras.ops.isfinite(metrics["loss"])
+
+
 def test_fit(approximator, train_dataset, validation_dataset):
     approximator.compile(optimizer="AdamW")
     num_epochs = 1


### PR DESCRIPTION
Addresses #737 by using `min(K, batch_size - 1)` in `_sample_from_batch`.