### PR TITLE
Replace hardcoded float32 values with floatx()

### DIFF
--- a/bayesflow/approximators/helpers/compositional.py
+++ b/bayesflow/approximators/helpers/compositional.py
@@ -72,7 +72,7 @@ def build_prior_score_fn(
             prior_score = compute_prior_score(adapted_samples)
 
         for key in adapted_samples:
-            prior_score[key] = keras.ops.cast(prior_score[key], "float32")
+            prior_score[key] = keras.ops.cast(prior_score[key], keras.backend.floatx())
         prior_score = keras.tree.map_structure(keras.ops.convert_to_tensor, prior_score)
         return keras.ops.concatenate([prior_score[key] for key in adapted_samples], axis=-1)
 

--- a/bayesflow/approximators/helpers/compositional.py
+++ b/bayesflow/approximators/helpers/compositional.py
@@ -72,7 +72,7 @@ def build_prior_score_fn(
             prior_score = compute_prior_score(adapted_samples)
 
         for key in adapted_samples:
-            prior_score[key] = keras.ops.cast(prior_score[key], keras.backend.floatx())
+            prior_score[key] = keras.ops.cast(prior_score[key], keras.config.floatx())
         prior_score = keras.tree.map_structure(keras.ops.convert_to_tensor, prior_score)
         return keras.ops.concatenate([prior_score[key] for key in adapted_samples], axis=-1)
 

--- a/bayesflow/approximators/ratio_approximator.py
+++ b/bayesflow/approximators/ratio_approximator.py
@@ -280,7 +280,7 @@ class RatioApproximator(Approximator):
         # Sample from (B, B-1) space in O(B*K) instead of O(B^2)
         scores = keras.random.uniform(
             shape=(B, B - 1),
-            dtype=keras.backend.floatx(),
+            dtype=keras.config.floatx(),
             seed=self.seed_generator,
         )
         _, idx = keras.ops.top_k(scores, k=num_contrastive)

--- a/bayesflow/approximators/ratio_approximator.py
+++ b/bayesflow/approximators/ratio_approximator.py
@@ -280,7 +280,7 @@ class RatioApproximator(Approximator):
         # Sample from (B, B-1) space in O(B*K) instead of O(B^2)
         scores = keras.random.uniform(
             shape=(B, B - 1),
-            dtype="float32",
+            dtype=keras.backend.floatx(),
             seed=self.seed_generator,
         )
         _, idx = keras.ops.top_k(scores, k=num_contrastive)

--- a/bayesflow/diagnostics/metrics/model_misspecification.py
+++ b/bayesflow/diagnostics/metrics/model_misspecification.py
@@ -59,7 +59,7 @@ def bootstrap_comparison(
             f"but got {observed_samples.shape[1:]} != {reference_samples.shape[1:]}."
         )
 
-    dtype = keras.backend.floatx()
+    dtype = keras.config.floatx()
     observed_samples = keras.ops.convert_to_tensor(observed_samples, dtype=dtype)
     reference_samples = keras.ops.convert_to_tensor(reference_samples, dtype=dtype)
 

--- a/bayesflow/diagnostics/metrics/model_misspecification.py
+++ b/bayesflow/diagnostics/metrics/model_misspecification.py
@@ -6,8 +6,8 @@ distributions within the reference samples for hypothesis testing.
 from collections.abc import Mapping, Callable
 
 import numpy as np
+
 import keras
-from keras.ops import convert_to_numpy, convert_to_tensor
 
 from bayesflow.approximators import ContinuousApproximator
 from bayesflow.metrics.functional import maximum_mean_discrepancy
@@ -19,7 +19,7 @@ def bootstrap_comparison(
     reference_samples: np.ndarray,
     comparison_fn: Callable[[Tensor, Tensor], Tensor],
     num_null_samples: int = 100,
-) -> tuple[float, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """Computes the distance between observed and reference samples and generates a distribution of null sample
     distances by bootstrapping for hypothesis testing.
 
@@ -36,8 +36,8 @@ def bootstrap_comparison(
 
     Returns
     -------
-    distance_observed : float
-        The distance value between observed and reference samples.
+    distance_observed : np.ndarray
+        A scalar NumPy array containing the distance between observed and reference samples.
     distance_null : np.ndarray
         A distribution of distance values under the null hypothesis.
 
@@ -47,14 +47,12 @@ def bootstrap_comparison(
         - If the number of number of observed samples exceeds the number of reference samples
         - If the shapes of observed and reference samples do not match on dimensions besides the first one.
     """
+    observed_samples = np.asarray(observed_samples)
+    reference_samples = np.asarray(reference_samples)
+
     num_observed = observed_samples.shape[0]
     num_reference = reference_samples.shape[0]
 
-    if num_observed > num_reference:
-        raise ValueError(
-            f"Number of observed samples ({num_observed}) cannot exceed"
-            f"the number of reference samples ({num_reference}) for bootstrapping."
-        )
     if observed_samples.shape[1:] != reference_samples.shape[1:]:
         raise ValueError(
             f"Expected observed and reference samples to have the same shape, "
@@ -62,23 +60,21 @@ def bootstrap_comparison(
         )
 
     dtype = keras.backend.floatx()
-    observed_samples_tensor = convert_to_tensor(observed_samples, dtype=dtype)
-    reference_samples_tensor = convert_to_tensor(reference_samples, dtype=dtype)
+    observed_samples = keras.ops.convert_to_tensor(observed_samples, dtype=dtype)
+    reference_samples = keras.ops.convert_to_tensor(reference_samples, dtype=dtype)
 
-    distance_null_samples = np.zeros(num_null_samples, dtype=dtype)
+    distance_observed = comparison_fn(observed_samples, reference_samples)
+    distance_observed = keras.ops.convert_to_numpy(distance_observed)
 
+    if distance_observed.ndim != 0:
+        raise ValueError(f"Expected comparison_fn to return a scalar, but got shape {distance_observed.shape}.")
+
+    distance_null_samples = np.empty(num_null_samples, dtype=distance_observed.dtype)
     for i in range(num_null_samples):
-        bootstrap_idx = np.random.randint(0, num_reference, size=num_observed)
-        bootstrap_samples = reference_samples[bootstrap_idx]
-        bootstrap_samples_tensor = convert_to_tensor(bootstrap_samples, dtype=dtype)
-        distance_null_samples[i] = convert_to_numpy(comparison_fn(bootstrap_samples_tensor, reference_samples_tensor))
-
-    distance_observed_tensor = comparison_fn(
-        observed_samples_tensor,
-        reference_samples_tensor,
-    )
-
-    distance_observed = convert_to_numpy(distance_observed_tensor)
+        bootstrap_indices = np.random.randint(num_reference, size=num_observed)
+        bootstrap_samples = keras.ops.take(reference_samples, bootstrap_indices, axis=0)
+        distance_null = comparison_fn(bootstrap_samples, reference_samples)
+        distance_null_samples[i] = keras.ops.convert_to_numpy(distance_null)
 
     return distance_observed, distance_null_samples
 
@@ -90,7 +86,7 @@ def summary_space_comparison(
     num_null_samples: int = 100,
     comparison_fn: Callable = maximum_mean_discrepancy,
     **kwargs,
-) -> tuple[float, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """Computes the distance between observed and reference data in the summary space and
     generates a distribution of distance values under the null hypothesis to assess model misspecification.
 
@@ -120,8 +116,8 @@ def summary_space_comparison(
 
     Returns
     -------
-    distance_observed : float
-        The MMD value between observed and reference summaries.
+    distance_observed : np.ndarray
+        A scalar NumPy array containing the MMD value between observed and reference summaries.
     distance_null : np.ndarray
         A distribution of MMD values under the null hypothesis.
 
@@ -145,8 +141,9 @@ def summary_space_comparison(
             "statistics, or want to compare raw data and not summary statistics, please use the "
             f"`bootstrap_comparison` function with `comparison_fn={comparison_fn_name}` on the respective arrays."
         )
-    observed_summaries = convert_to_numpy(approximator.summarize(observed_data))
-    reference_summaries = convert_to_numpy(approximator.summarize(reference_data))
+
+    observed_summaries = approximator.summarize(observed_data)
+    reference_summaries = approximator.summarize(reference_data)
 
     distance_observed, distance_null = bootstrap_comparison(
         observed_samples=observed_summaries,

--- a/bayesflow/diagnostics/metrics/model_misspecification.py
+++ b/bayesflow/diagnostics/metrics/model_misspecification.py
@@ -6,6 +6,7 @@ distributions within the reference samples for hypothesis testing.
 from collections.abc import Mapping, Callable
 
 import numpy as np
+import keras
 from keras.ops import convert_to_numpy, convert_to_tensor
 
 from bayesflow.approximators import ContinuousApproximator
@@ -24,7 +25,7 @@ def bootstrap_comparison(
 
     Parameters
     ----------
-    observed_samples : np.ndarray)
+    observed_samples : np.ndarray
         Observed samples, shape (num_observed, ...).
     reference_samples : np.ndarray
         Reference samples, shape (num_reference, ...).
@@ -60,22 +61,24 @@ def bootstrap_comparison(
             f"but got {observed_samples.shape[1:]} != {reference_samples.shape[1:]}."
         )
 
-    observed_samples_tensor: Tensor = convert_to_tensor(observed_samples, dtype="float32")
-    reference_samples_tensor: Tensor = convert_to_tensor(reference_samples, dtype="float32")
+    dtype = keras.backend.floatx()
+    observed_samples_tensor = convert_to_tensor(observed_samples, dtype=dtype)
+    reference_samples_tensor = convert_to_tensor(reference_samples, dtype=dtype)
 
-    distance_null_samples: np.ndarray = np.zeros(num_null_samples, dtype=np.float64)
+    distance_null_samples = np.zeros(num_null_samples, dtype=dtype)
+
     for i in range(num_null_samples):
-        bootstrap_idx: np.ndarray = np.random.randint(0, num_reference, size=num_observed)
-        bootstrap_samples: np.ndarray = reference_samples[bootstrap_idx]
-        bootstrap_samples_tensor: Tensor = convert_to_tensor(bootstrap_samples, dtype="float32")
+        bootstrap_idx = np.random.randint(0, num_reference, size=num_observed)
+        bootstrap_samples = reference_samples[bootstrap_idx]
+        bootstrap_samples_tensor = convert_to_tensor(bootstrap_samples, dtype=dtype)
         distance_null_samples[i] = convert_to_numpy(comparison_fn(bootstrap_samples_tensor, reference_samples_tensor))
 
-    distance_observed_tensor: Tensor = comparison_fn(
+    distance_observed_tensor = comparison_fn(
         observed_samples_tensor,
         reference_samples_tensor,
     )
 
-    distance_observed: float = float(convert_to_numpy(distance_observed_tensor))
+    distance_observed = convert_to_numpy(distance_observed_tensor)
 
     return distance_observed, distance_null_samples
 

--- a/bayesflow/distributions/diagonal_normal.py
+++ b/bayesflow/distributions/diagonal_normal.py
@@ -67,7 +67,7 @@ class DiagonalNormal(Distribution):
             return
 
         self.dim = input_shape[-1]
-        dtype = keras.backend.floatx()
+        dtype = keras.config.floatx()
 
         self.mean = ops.cast(ops.broadcast_to(self.mean, (self.dim,)), dtype)
         self.std = ops.cast(ops.broadcast_to(self.std, (self.dim,)), dtype)

--- a/bayesflow/distributions/diagonal_normal.py
+++ b/bayesflow/distributions/diagonal_normal.py
@@ -67,21 +67,22 @@ class DiagonalNormal(Distribution):
             return
 
         self.dim = input_shape[-1]
+        dtype = keras.backend.floatx()
 
-        self.mean = ops.cast(ops.broadcast_to(self.mean, (self.dim,)), "float32")
-        self.std = ops.cast(ops.broadcast_to(self.std, (self.dim,)), "float32")
+        self.mean = ops.cast(ops.broadcast_to(self.mean, (self.dim,)), dtype)
+        self.std = ops.cast(ops.broadcast_to(self.std, (self.dim,)), dtype)
 
         if self.trainable_parameters:
             self._mean = self.add_weight(
                 shape=ops.shape(self.mean),
                 initializer=keras.initializers.get(keras.ops.copy(self.mean)),
-                dtype="float32",
+                dtype=dtype,
                 trainable=True,
             )
             self._std = self.add_weight(
                 shape=ops.shape(self.std),
                 initializer=keras.initializers.get(keras.ops.copy(self.std)),
-                dtype="float32",
+                dtype=dtype,
                 trainable=True,
             )
         else:

--- a/bayesflow/distributions/diagonal_student_t.py
+++ b/bayesflow/distributions/diagonal_student_t.py
@@ -73,22 +73,23 @@ class DiagonalStudentT(Distribution):
             return
 
         self.dim = input_shape[-1]
+        dtype = keras.backend.floatx()
 
         # convert to tensor and broadcast if necessary
-        self.loc = ops.cast(ops.broadcast_to(self.loc, (self.dim,)), "float32")
-        self.scale = ops.cast(ops.broadcast_to(self.scale, (self.dim,)), "float32")
+        self.loc = ops.cast(ops.broadcast_to(self.loc, (self.dim,)), dtype)
+        self.scale = ops.cast(ops.broadcast_to(self.scale, (self.dim,)), dtype)
 
         if self.trainable_parameters:
             self._loc = self.add_weight(
                 shape=ops.shape(self.loc),
                 initializer=keras.initializers.get(keras.ops.copy(self.loc)),
-                dtype="float32",
+                dtype=dtype,
                 trainable=True,
             )
             self._scale = self.add_weight(
                 shape=ops.shape(self.scale),
                 initializer=keras.initializers.get(keras.ops.copy(self.scale)),
-                dtype="float32",
+                dtype=dtype,
                 trainable=True,
             )
         else:

--- a/bayesflow/distributions/diagonal_student_t.py
+++ b/bayesflow/distributions/diagonal_student_t.py
@@ -73,7 +73,7 @@ class DiagonalStudentT(Distribution):
             return
 
         self.dim = input_shape[-1]
-        dtype = keras.backend.floatx()
+        dtype = keras.config.floatx()
 
         # convert to tensor and broadcast if necessary
         self.loc = ops.cast(ops.broadcast_to(self.loc, (self.dim,)), dtype)

--- a/bayesflow/distributions/mixture.py
+++ b/bayesflow/distributions/mixture.py
@@ -139,7 +139,7 @@ class Mixture(Distribution):
         self._mixture_logits = self.add_weight(
             shape=(len(self.distributions),),
             initializer=keras.initializers.get(keras.ops.copy(self.mixture_logits)),
-            dtype="float32",
+            dtype=keras.backend.floatx(),
             trainable=self.trainable_mixture,
         )
 

--- a/bayesflow/distributions/mixture.py
+++ b/bayesflow/distributions/mixture.py
@@ -139,7 +139,7 @@ class Mixture(Distribution):
         self._mixture_logits = self.add_weight(
             shape=(len(self.distributions),),
             initializer=keras.initializers.get(keras.ops.copy(self.mixture_logits)),
-            dtype=keras.backend.floatx(),
+            dtype=keras.config.floatx(),
             trainable=self.trainable_mixture,
         )
 

--- a/bayesflow/experimental/graphical_approximator/graphical_approximator.py
+++ b/bayesflow/experimental/graphical_approximator/graphical_approximator.py
@@ -446,7 +446,7 @@ class GraphicalApproximator(Approximator):
 
         # log_det_jac for adapter
         for key in ldj_adapter:
-            ldj = keras.ops.cast(ldj_adapter[key], "float32")
+            ldj = keras.ops.cast(ldj_adapter[key], keras.backend.floatx())
             log_prob += keras.ops.sum(keras.ops.reshape(ldj, (batch_size, -1)), axis=-1)
 
         return log_prob

--- a/bayesflow/experimental/graphical_approximator/graphical_approximator.py
+++ b/bayesflow/experimental/graphical_approximator/graphical_approximator.py
@@ -446,7 +446,7 @@ class GraphicalApproximator(Approximator):
 
         # log_det_jac for adapter
         for key in ldj_adapter:
-            ldj = keras.ops.cast(ldj_adapter[key], keras.backend.floatx())
+            ldj = keras.ops.cast(ldj_adapter[key], keras.config.floatx())
             log_prob += keras.ops.sum(keras.ops.reshape(ldj, (batch_size, -1)), axis=-1)
 
         return log_prob

--- a/bayesflow/experimental/graphical_approximator/inference_conditions.py
+++ b/bayesflow/experimental/graphical_approximator/inference_conditions.py
@@ -280,7 +280,7 @@ def inference_conditions_by_network(
     data_shape = keras.ops.shape(data_tensor)
     spatial_dims = [data_shape[i] for i in range(1, data_tensor.ndim - 1)]
     node_reps = keras.ops.expand_dims(
-        keras.ops.sqrt(keras.ops.cast(keras.ops.stack(spatial_dims), keras.backend.floatx())),
+        keras.ops.sqrt(keras.ops.cast(keras.ops.stack(spatial_dims), keras.config.floatx())),
         axis=0,
     )
 

--- a/bayesflow/experimental/graphical_approximator/inference_conditions.py
+++ b/bayesflow/experimental/graphical_approximator/inference_conditions.py
@@ -280,7 +280,7 @@ def inference_conditions_by_network(
     data_shape = keras.ops.shape(data_tensor)
     spatial_dims = [data_shape[i] for i in range(1, data_tensor.ndim - 1)]
     node_reps = keras.ops.expand_dims(
-        keras.ops.sqrt(keras.ops.cast(keras.ops.stack(spatial_dims), "float32")),
+        keras.ops.sqrt(keras.ops.cast(keras.ops.stack(spatial_dims), keras.backend.floatx())),
         axis=0,
     )
 

--- a/bayesflow/links/ordered_quantiles.py
+++ b/bayesflow/links/ordered_quantiles.py
@@ -43,7 +43,7 @@ class OrderedQuantiles(Ordered):
             )
         else:
             # choose quantile level closest to median as anchor index
-            q = keras.ops.convert_to_tensor(self.q, dtype=keras.backend.floatx())
+            q = keras.ops.convert_to_tensor(self.q, dtype=keras.config.floatx())
             self.anchor_index = int(keras.ops.argmin(keras.ops.abs(q - 0.5)))
 
             if len(self.q) != num_quantile_levels:

--- a/bayesflow/links/ordered_quantiles.py
+++ b/bayesflow/links/ordered_quantiles.py
@@ -43,7 +43,7 @@ class OrderedQuantiles(Ordered):
             )
         else:
             # choose quantile level closest to median as anchor index
-            q = keras.ops.convert_to_tensor(self.q, dtype="float32")
+            q = keras.ops.convert_to_tensor(self.q, dtype=keras.backend.floatx())
             self.anchor_index = int(keras.ops.argmin(keras.ops.abs(q - 0.5)))
 
             if len(self.q) != num_quantile_levels:

--- a/bayesflow/networks/inference/consistency/consistency_model.py
+++ b/bayesflow/networks/inference/consistency/consistency_model.py
@@ -185,7 +185,7 @@ class ConsistencyModel(InferenceNetwork):
         Section 2, bottom of page 2.
         """
 
-        dtype = keras.backend.floatx()
+        dtype = keras.config.floatx()
         indices = ops.arange(1, n_k + 1, dtype=dtype)
         one_over_rho = 1.0 / self.rho
         discretized_time = (
@@ -247,7 +247,7 @@ class ConsistencyModel(InferenceNetwork):
             discretization_map[n] = i
 
         # Finally, we convert the vectors to tensors
-        self._discretized_times = ops.convert_to_tensor(discretized_times, dtype=keras.backend.floatx())
+        self._discretized_times = ops.convert_to_tensor(discretized_times, dtype=keras.config.floatx())
         self._discretization_map = ops.convert_to_tensor(discretization_map)
 
     def _forward_train(

--- a/bayesflow/networks/inference/consistency/consistency_model.py
+++ b/bayesflow/networks/inference/consistency/consistency_model.py
@@ -184,13 +184,13 @@ class ConsistencyModel(InferenceNetwork):
         """Function for obtaining the discretized time according to [2],
         Section 2, bottom of page 2.
         """
-        indices = ops.arange(1, n_k + 1, dtype="float32")
+
+        dtype = keras.backend.floatx()
+        indices = ops.arange(1, n_k + 1, dtype=dtype)
         one_over_rho = 1.0 / self.rho
         discretized_time = (
             self.eps**one_over_rho
-            + (indices - 1.0)
-            / (ops.cast(n_k, "float32") - 1.0)
-            * (self.max_time**one_over_rho - self.eps**one_over_rho)
+            + (indices - 1.0) / (ops.cast(n_k, dtype) - 1.0) * (self.max_time**one_over_rho - self.eps**one_over_rho)
         ) ** self.rho
         return discretized_time
 
@@ -247,7 +247,7 @@ class ConsistencyModel(InferenceNetwork):
             discretization_map[n] = i
 
         # Finally, we convert the vectors to tensors
-        self._discretized_times = ops.convert_to_tensor(discretized_times, dtype="float32")
+        self._discretized_times = ops.convert_to_tensor(discretized_times, dtype=keras.backend.floatx())
         self._discretization_map = ops.convert_to_tensor(discretization_map)
 
     def _forward_train(

--- a/bayesflow/networks/inference/scoring/scoring_rule_network.py
+++ b/bayesflow/networks/inference/scoring/scoring_rule_network.py
@@ -169,7 +169,7 @@ class ScoringRuleNetwork(keras.Layer):
 
         if conditions is None:
             conditions = keras.ops.convert_to_tensor(
-                [[1.0]], dtype=keras.ops.dtype(xz) if xz is not None else keras.backend.floatx()
+                [[1.0]], dtype=keras.ops.dtype(xz) if xz is not None else keras.config.floatx()
             )
 
         output = self.subnet(conditions, training=training, **kwargs)
@@ -228,7 +228,7 @@ class ScoringRuleNetwork(keras.Layer):
         """
         seed_generator = resolve_seed(seed)
         if conditions is None:
-            conditions = keras.ops.convert_to_tensor([[1.0]], dtype=keras.backend.floatx())
+            conditions = keras.ops.convert_to_tensor([[1.0]], dtype=keras.config.floatx())
 
         output = self.subnet(conditions)
         samples = {}

--- a/bayesflow/networks/inference/scoring/scoring_rule_network.py
+++ b/bayesflow/networks/inference/scoring/scoring_rule_network.py
@@ -169,7 +169,7 @@ class ScoringRuleNetwork(keras.Layer):
 
         if conditions is None:
             conditions = keras.ops.convert_to_tensor(
-                [[1.0]], dtype=keras.ops.dtype(xz) if xz is not None else "float32"
+                [[1.0]], dtype=keras.ops.dtype(xz) if xz is not None else keras.backend.floatx()
             )
 
         output = self.subnet(conditions, training=training, **kwargs)
@@ -228,7 +228,7 @@ class ScoringRuleNetwork(keras.Layer):
         """
         seed_generator = resolve_seed(seed)
         if conditions is None:
-            conditions = keras.ops.convert_to_tensor([[1.0]], dtype="float32")
+            conditions = keras.ops.convert_to_tensor([[1.0]], dtype=keras.backend.floatx())
 
         output = self.subnet(conditions)
         samples = {}

--- a/bayesflow/networks/inference/scoring/scoring_rules/exponential_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/exponential_score.py
@@ -66,7 +66,7 @@ class ExponentialScore(CategoricalScoringRule):
         """
         diff = logits_relative_to_target(estimates["logits"], targets)
         mask = 1.0 - targets
-        M = keras.ops.cast(keras.ops.shape(diff)[-1], dtype="float32")
+        M = keras.ops.cast(keras.ops.shape(diff)[-1], dtype=keras.backend.floatx())
         clip_max = FLOAT32_EXP_MAX - keras.ops.log(keras.ops.maximum(M - 1.0, 1.0))
         half_diff = 0.5 * diff
         scores = keras.ops.sum(

--- a/bayesflow/networks/inference/scoring/scoring_rules/exponential_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/exponential_score.py
@@ -66,7 +66,7 @@ class ExponentialScore(CategoricalScoringRule):
         """
         diff = logits_relative_to_target(estimates["logits"], targets)
         mask = 1.0 - targets
-        M = keras.ops.cast(keras.ops.shape(diff)[-1], dtype=keras.backend.floatx())
+        M = keras.ops.cast(keras.ops.shape(diff)[-1], dtype=keras.config.floatx())
         clip_max = FLOAT32_EXP_MAX - keras.ops.log(keras.ops.maximum(M - 1.0, 1.0))
         half_diff = 0.5 * diff
         scores = keras.ops.sum(

--- a/bayesflow/networks/inference/scoring/scoring_rules/logistic_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/logistic_score.py
@@ -81,7 +81,7 @@ class LogisticScore(CategoricalScoringRule):
         if self.alpha == 0:
             scores = keras.ops.sum(mask * log_terms, axis=-1)
         else:
-            M = keras.ops.cast(keras.ops.shape(diff)[-1], dtype=keras.backend.floatx())
+            M = keras.ops.cast(keras.ops.shape(diff)[-1], dtype=keras.config.floatx())
             clip_max = FLOAT32_EXP_MAX - keras.ops.log(keras.ops.maximum(M - 1.0, 1.0))
             scores = keras.ops.sum(
                 mask * keras.ops.exp(keras.ops.minimum(self.alpha * log_terms, clip_max)),

--- a/bayesflow/networks/inference/scoring/scoring_rules/logistic_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/logistic_score.py
@@ -81,7 +81,7 @@ class LogisticScore(CategoricalScoringRule):
         if self.alpha == 0:
             scores = keras.ops.sum(mask * log_terms, axis=-1)
         else:
-            M = keras.ops.cast(keras.ops.shape(diff)[-1], dtype="float32")
+            M = keras.ops.cast(keras.ops.shape(diff)[-1], dtype=keras.backend.floatx())
             clip_max = FLOAT32_EXP_MAX - keras.ops.log(keras.ops.maximum(M - 1.0, 1.0))
             scores = keras.ops.sum(
                 mask * keras.ops.exp(keras.ops.minimum(self.alpha * log_terms, clip_max)),

--- a/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
@@ -86,7 +86,9 @@ class MixtureScore(ParametricDistributionScore):
         self.weight_head = weight_head
 
         # Temperature is a non-trainable variable so it can be updated by external schedules.
-        self.temperature = keras.Variable(temperature, trainable=False, dtype="float32", name="mixture_temperature")
+        self.temperature = keras.Variable(
+            temperature, trainable=False, dtype=keras.backend.floatx(), name="mixture_temperature"
+        )
 
         # Ensure mixture logits are not inverse-standardized like inference variables.
         # Components may define their own transformation types.

--- a/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
@@ -87,7 +87,7 @@ class MixtureScore(ParametricDistributionScore):
 
         # Temperature is a non-trainable variable so it can be updated by external schedules.
         self.temperature = keras.Variable(
-            temperature, trainable=False, dtype=keras.backend.floatx(), name="mixture_temperature"
+            temperature, trainable=False, dtype=keras.config.floatx(), name="mixture_temperature"
         )
 
         # Ensure mixture logits are not inverse-standardized like inference variables.

--- a/bayesflow/networks/inference/scoring/scoring_rules/quantile_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/quantile_score.py
@@ -28,7 +28,7 @@ class QuantileScore(ScoringRule):
         # force a conversion to list for proper serialization
         q = list(q)
         self.q = q
-        self._q = keras.ops.convert_to_tensor(q, dtype="float32")
+        self._q = keras.ops.convert_to_tensor(q, dtype=keras.backend.floatx())
         self.links = links or {"value": OrderedQuantiles(q=q)}
 
         self.config = {

--- a/bayesflow/networks/inference/scoring/scoring_rules/quantile_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/quantile_score.py
@@ -28,7 +28,7 @@ class QuantileScore(ScoringRule):
         # force a conversion to list for proper serialization
         q = list(q)
         self.q = q
-        self._q = keras.ops.convert_to_tensor(q, dtype=keras.backend.floatx())
+        self._q = keras.ops.convert_to_tensor(q, dtype=keras.config.floatx())
         self.links = links or {"value": OrderedQuantiles(q=q)}
 
         self.config = {

--- a/bayesflow/utils/integrate.py
+++ b/bayesflow/utils/integrate.py
@@ -357,12 +357,13 @@ def integrate_adaptive(
         case other:
             raise TypeError(f"Invalid integration method: {other!r}")
 
-    # density computation (state carries more than one entry) needs higher accuracy than sampling,
-    atol = keras.ops.convert_to_tensor(kwargs.get("atol", 1e-6), dtype="float32")
-    rtol = keras.ops.convert_to_tensor(kwargs.get("rtol", 1e-4 if len(state) == 1 else 1e-5), dtype="float32")
-    initial_step = keras.ops.convert_to_tensor((stop_time - start_time) / float(min_steps), dtype="float32")
-    step0 = keras.ops.convert_to_tensor(0.0, dtype="float32")
-    count_not_accepted = keras.ops.convert_to_tensor(0.0, dtype="float32")
+    # density computation (state carries more than one entry) needs higher accuracy than sampling
+    dtype = keras.backend.floatx()
+    atol = keras.ops.convert_to_tensor(kwargs.get("atol", 1e-6), dtype=dtype)
+    rtol = keras.ops.convert_to_tensor(kwargs.get("rtol", 1e-4 if len(state) == 1 else 1e-5), dtype=dtype)
+    initial_step = keras.ops.convert_to_tensor((stop_time - start_time) / float(min_steps), dtype=dtype)
+    step0 = keras.ops.convert_to_tensor(0.0, dtype=dtype)
+    count_not_accepted = keras.ops.convert_to_tensor(0.0, dtype=dtype)
 
     # "First Same As Last" (FSAL) property
     k1_0 = fn(start_time, **filter_kwargs(state, fn))
@@ -488,7 +489,7 @@ def integrate_scipy(
 
     def scipy_wrapper_fn(time, x):
         state = vector_to_state(x)
-        time = keras.ops.convert_to_tensor(time, dtype="float32")
+        time = keras.ops.convert_to_tensor(time, dtype=keras.backend.floatx())
         deltas = fn(time, **filter_kwargs(state, fn))
         return state_to_vector(deltas)
 

--- a/bayesflow/utils/integrate.py
+++ b/bayesflow/utils/integrate.py
@@ -358,7 +358,7 @@ def integrate_adaptive(
             raise TypeError(f"Invalid integration method: {other!r}")
 
     # density computation (state carries more than one entry) needs higher accuracy than sampling
-    dtype = keras.backend.floatx()
+    dtype = keras.config.floatx()
     atol = keras.ops.convert_to_tensor(kwargs.get("atol", 1e-6), dtype=dtype)
     rtol = keras.ops.convert_to_tensor(kwargs.get("rtol", 1e-4 if len(state) == 1 else 1e-5), dtype=dtype)
     initial_step = keras.ops.convert_to_tensor((stop_time - start_time) / float(min_steps), dtype=dtype)
@@ -489,7 +489,7 @@ def integrate_scipy(
 
     def scipy_wrapper_fn(time, x):
         state = vector_to_state(x)
-        time = keras.ops.convert_to_tensor(time, dtype=keras.backend.floatx())
+        time = keras.ops.convert_to_tensor(time, dtype=keras.config.floatx())
         deltas = fn(time, **filter_kwargs(state, fn))
         return state_to_vector(deltas)
 

--- a/bayesflow/utils/keras_utils.py
+++ b/bayesflow/utils/keras_utils.py
@@ -25,7 +25,7 @@ def resolve_seed(seed):
 def multinomial_allocation(weights: Mapping[str, float], num_samples: int, seed=None) -> dict[str, int]:
     """Allocate `num_samples` draws across `weights` via multinomial sampling."""
     names = tuple(weights.keys())
-    probs = np.array(list(weights.values()), dtype=keras.backend.floatx())
+    probs = np.array(list(weights.values()), dtype=keras.config.floatx())
 
     num_categories = len(probs)
     logits_broadcast = keras.ops.broadcast_to(

--- a/bayesflow/utils/masks.py
+++ b/bayesflow/utils/masks.py
@@ -86,7 +86,7 @@ def random_mask(
     if drop_prob <= 0:
         return 1.0
 
-    dtype = keras.backend.floatx()
+    dtype = keras.config.floatx()
     random_vals = keras.random.uniform(shape=shape, dtype=dtype, seed=seed_generator)
     mask = keras.ops.cast(random_vals > drop_prob, dtype=dtype)
     if keep_one:

--- a/bayesflow/wrappers/pymc/neural_distribution.py
+++ b/bayesflow/wrappers/pymc/neural_distribution.py
@@ -77,7 +77,7 @@ class NeuralDistribution:
         simulator_fn: Callable | None = None,
     ):
         # Match float precision of pytensor with keras
-        pytensor.config.floatX = keras.backend.floatx()
+        pytensor.config.floatX = keras.config.floatx()
 
         self.param_names = tuple(param_names)
         self.exchangeable = exchangeable
@@ -161,7 +161,7 @@ class NeuralDistribution:
         custom_kwargs = {
             "logp": self.logp,
             "signature": signature,
-            "dtype": keras.backend.floatx(),
+            "dtype": keras.config.floatx(),
         }
 
         if self.simulator_fn is not None:

--- a/bayesflow/wrappers/pymc/ratio_distribution.py
+++ b/bayesflow/wrappers/pymc/ratio_distribution.py
@@ -229,7 +229,7 @@ class NeuralRatioDistribution:
         custom_kwargs = {
             "logp": self.logp,
             "signature": signature,
-            "dtype": keras.backend.floatx(),
+            "dtype": keras.config.floatx(),
         }
 
         if self.simulator_fn is not None:

--- a/tests/test_diagnostics/test_diagnostics_metrics.py
+++ b/tests/test_diagnostics/test_diagnostics_metrics.py
@@ -268,7 +268,8 @@ def test_bootstrap_comparison_shapes():
         num_null_samples,
     )
 
-    assert isinstance(distance_observed, float)
+    assert isinstance(distance_observed, np.ndarray)
+    assert distance_observed.shape == ()
     assert isinstance(distance_null, np.ndarray)
     assert distance_null.shape == (num_null_samples,)
 
@@ -349,7 +350,8 @@ def test_mmd_comparison_from_summaries_shapes():
         num_null_samples=num_null_samples,
     )
 
-    assert isinstance(mmd_observed, float)
+    assert isinstance(mmd_observed, np.ndarray)
+    assert mmd_observed.shape == ()
     assert isinstance(mmd_null, np.ndarray)
     assert mmd_null.shape == (num_null_samples,)
 

--- a/tests/test_diagnostics/test_diagnostics_metrics.py
+++ b/tests/test_diagnostics/test_diagnostics_metrics.py
@@ -268,9 +268,7 @@ def test_bootstrap_comparison_shapes():
         num_null_samples,
     )
 
-    assert isinstance(distance_observed, np.ndarray)
     assert distance_observed.shape == ()
-    assert isinstance(distance_null, np.ndarray)
     assert distance_null.shape == (num_null_samples,)
 
 
@@ -334,9 +332,7 @@ def test_mmd_comparison_from_summaries_shapes():
         num_null_samples=num_null_samples,
     )
 
-    assert isinstance(mmd_observed, np.ndarray)
     assert mmd_observed.shape == ()
-    assert isinstance(mmd_null, np.ndarray)
     assert mmd_null.shape == (num_null_samples,)
 
 
@@ -409,8 +405,7 @@ def test_mmd_comparison_shapes(summary_network, adapter):
         comparison_fn=bf.metrics.functional.maximum_mean_discrepancy,
     )
 
-    assert isinstance(mmd_observed, float)
-    assert isinstance(mmd_null, np.ndarray)
+    assert mmd_observed.shape == ()
     assert mmd_null.shape == (num_null_samples,)
 
 

--- a/tests/test_diagnostics/test_diagnostics_metrics.py
+++ b/tests/test_diagnostics/test_diagnostics_metrics.py
@@ -321,22 +321,6 @@ def test_bootstrap_comparison_mismatched_shapes():
         )
 
 
-def test_bootstrap_comparison_num_observed_exceeds_num_reference():
-    """Test bootstrap_comparison raises ValueError when number of observed samples exceeds the number of reference
-    samples."""
-    observed_samples = np.random.rand(100, 5)
-    reference_samples = np.random.rand(20, 5)
-    num_null_samples = 50
-
-    with pytest.raises(ValueError):
-        bf.diagnostics.metrics.bootstrap_comparison(
-            observed_samples,
-            reference_samples,
-            lambda x, y: keras.ops.abs(keras.ops.mean(x) - keras.ops.mean(y)),
-            num_null_samples,
-        )
-
-
 def test_mmd_comparison_from_summaries_shapes():
     """Test the mmd_comparison_from_summaries output shapes."""
     observed_summaries = np.random.rand(10, 5)

--- a/tests/utils/normal_simulator.py
+++ b/tests/utils/normal_simulator.py
@@ -18,7 +18,4 @@ class NormalSimulator(Simulator):
         # flatten observations for use without summary network
         x = x.reshape(x.shape[0], -1)
 
-        mean = mean.astype("float32")
-        std = std.astype("float32")
-        x = x.astype("float32")
         return dict(mean=mean, std=std, x=x)


### PR DESCRIPTION
Replaces hardcoded `float32` values (e.g., in distribution parameter inits), integrators to use `keras.backend.floatx()`. Does not touch adapter transforms yet, as these will be superseded by #747.