### PR TITLE
fix minor bug in aggregation of ensemble approximator losses

### DIFF
--- a/bayesflow/approximators/ensemble_approximator.py
+++ b/bayesflow/approximators/ensemble_approximator.py
@@ -212,14 +212,14 @@ class EnsembleApproximator(Approximator):
                 stage=stage,
             )
 
+        loss = keras.ops.sum([approx_metrics["loss"] for approx_metrics in metrics.values()])
+
         metrics = {
             f"{approx_name}/{metric_key}": value
             for approx_name, approx_metrics in metrics.items()
             for metric_key, value in approx_metrics.items()
         }
-
-        losses = [v for k, v in metrics.items() if "loss" in k]
-        metrics["loss"] = keras.ops.sum(losses)
+        metrics["loss"] = loss
 
         return metrics
 


### PR DESCRIPTION
Because the losses were collected with simple substring matching an approximator with a summary loss would be counted twice, effectively reweighting these members higher than members without a summary loss.

Most likely, nobody has actually experienced this yet though.