### PR TITLE
Decouple FlashAttention fast path from training dropout

### DIFF
--- a/bayesflow/networks/transformers/attention.py
+++ b/bayesflow/networks/transformers/attention.py
@@ -1,0 +1,110 @@
+import inspect
+
+import keras
+import keras.ops as ops
+
+from bayesflow.utils.serialization import serializable
+
+# Keras 3.12 folds causal masking into `attention_mask` before calling
+# `_compute_attention`, while newer versions pass `use_causal_mask` explicitly.
+# Inspect the method once so the fallback works with both signatures.
+_BASE_COMPUTE_ATTENTION_ACCEPTS_USE_CAUSAL_MASK = (
+    "use_causal_mask" in inspect.signature(keras.layers.MultiHeadAttention._compute_attention).parameters
+)
+
+
+@serializable("bayesflow.networks")
+class FlashMultiHeadAttention(keras.layers.MultiHeadAttention):
+    """Multi-head attention with a fused inference path independent of training dropout.
+
+    Keras normally uses :func:`keras.ops.dot_product_attention`, which can dispatch to
+    FlashAttention, only when the layer's configured dropout rate is zero. Consequently,
+    configuring dropout for training also disables fused attention during inference, even though
+    dropout is inactive then.
+
+    This layer preserves standard dropout-enabled attention during training and uses fused
+    dot-product attention during inference. When ``dropout == 0``, the fused path is also available
+    during training. Calls that request attention scores continue to use the standard path.
+
+    Notes
+    -----
+    The implementation overrides Keras's ``_compute_attention`` method and accesses the private
+    attributes ``_dropout``, ``_attention_axes``, and ``_inverse_sqrt_key_dim``. Compatibility is
+    therefore covered by dedicated tests. Keras 3.12 and newer releases also use different
+    ``_compute_attention`` signatures for causal masking; the module-level signature check handles
+    both forms.
+    """
+
+    def __init__(self, *args, dropout: float = 0.0, flash_attention: bool | None = None, **kwargs):
+        """Create a multi-head attention layer with an inference-time fused path.
+
+        Parameters
+        ----------
+        dropout : float, optional (default - 0.0)
+            Dropout applied to attention scores during training.
+        flash_attention : bool or None, optional (default - None)
+            FlashAttention policy for eligible fused calls. ``None`` defers to
+            ``keras.config.is_flash_attention_enabled()`` when the attention computation is traced
+            or executed; ``True`` requires it; ``False`` disables it while retaining fused
+            dot-product attention. This setting does not affect training calls with nonzero dropout
+            or calls that request attention scores.
+        *args, **kwargs
+            Additional arguments forwarded to :class:`keras.layers.MultiHeadAttention`.
+        """
+        # Initialize Keras with a valid dropout/FlashAttention combination, then restore the
+        # requested dropout before the layer is built. This class manages FlashAttention for its
+        # fused path separately through `_fast_path_flash_attention`.
+        super().__init__(*args, dropout=0.0, flash_attention=False, **kwargs)
+        self._dropout = dropout
+        self._flash_attention = False
+        self._fast_path_flash_attention = flash_attention
+
+    def _compute_attention(
+        self,
+        query,
+        key,
+        value,
+        attention_mask=None,
+        training=None,
+        return_attention_scores=False,
+        use_causal_mask=False,
+    ):
+        use_fast_path = not ((self._dropout > 0.0 and training) or return_attention_scores or (len(query.shape) != 4))
+        if not use_fast_path:
+            fallback_kwargs = dict(
+                attention_mask=attention_mask,
+                training=training,
+                return_attention_scores=return_attention_scores,
+            )
+            if _BASE_COMPUTE_ATTENTION_ACCEPTS_USE_CAUSAL_MASK:
+                fallback_kwargs["use_causal_mask"] = use_causal_mask
+            return super()._compute_attention(query, key, value, **fallback_kwargs)
+
+        if attention_mask is not None:
+            # Expand `(B, T, S)` masks for broadcasting over attention heads.
+            mask_expansion_axis = -len(self._attention_axes) * 2 - 1
+            for _ in range(4 - len(attention_mask.shape)):
+                attention_mask = ops.expand_dims(attention_mask, axis=mask_expansion_axis)
+            attention_mask = ops.cast(attention_mask, dtype="bool")
+
+        flash_attention = self._fast_path_flash_attention
+        if flash_attention is None:
+            # `ops.dot_product_attention` doesn't consult the global flash-attention setting
+            # itself, so resolve it here instead of leaving `flash_attention=None`.
+            flash_attention = keras.config.is_flash_attention_enabled()
+
+        attention_output = ops.dot_product_attention(
+            query=query,
+            key=key,
+            value=value,
+            bias=None,
+            mask=attention_mask,
+            scale=self._inverse_sqrt_key_dim,
+            is_causal=use_causal_mask,
+            flash_attention=flash_attention,
+        )
+        return attention_output, None
+
+    def get_config(self):
+        config = {"flash_attention": self._fast_path_flash_attention}
+        return {**super().get_config(), **config}

--- a/bayesflow/networks/transformers/fusion_transformer.py
+++ b/bayesflow/networks/transformers/fusion_transformer.py
@@ -31,6 +31,7 @@ class FusionTransformer(SummaryNetwork):
         template_type: str = "lstm",
         bidirectional: bool = True,
         template_dim: int = 128,
+        flash_attention: bool | None = None,
         **kwargs,
     ):
         """Creates a fusion transformer used to flexibly compress time series and learn additional time embeddings
@@ -77,6 +78,9 @@ class FusionTransformer(SummaryNetwork):
             units (equiv. output dimensions) of the recurrent network.
         time_axis     : int, optional (default - None)
             The time axis (e.g., -1 for last axis) from which to grab the time vector that goes into t2v.
+        flash_attention : bool or None, optional (default - None)
+            Whether to use flash attention for the internal attention computation. See
+            `MultiHeadAttentionBlock` for details.
         **kwargs : dict
             Additional keyword arguments passed to the base layer.
         """
@@ -95,6 +99,7 @@ class FusionTransformer(SummaryNetwork):
                 kernel_initializer=kernel_initializer,
                 use_bias=use_bias,
                 layer_norm=layer_norm,
+                flash_attention=flash_attention,
                 num_heads=num_heads[i],
                 embed_dim=embed_dims[i],
                 mlp_depth=mlp_depths[i],

--- a/bayesflow/networks/transformers/isab.py
+++ b/bayesflow/networks/transformers/isab.py
@@ -29,6 +29,7 @@ class InducedSetAttentionBlock(keras.Layer):
         kernel_initializer: str = "lecun_normal",
         use_bias: bool = True,
         layer_norm: bool = True,
+        flash_attention: bool | None = None,
         **kwargs,
     ):
         """Creates a self-attention attention block with inducing points (ISAB) which will typically
@@ -56,6 +57,9 @@ class InducedSetAttentionBlock(keras.Layer):
             Whether to include bias terms in dense layers, by default True.
         layer_norm : bool, optional
             Whether to apply layer normalization before and after attention, by default True.
+        flash_attention : bool or None, optional (default - None)
+            Whether to use flash attention for the internal attention computation. See
+            `MultiHeadAttentionBlock` for details.
         **kwargs : dict
             Additional keyword arguments passed to the Keras Layer base class.
         """
@@ -78,6 +82,7 @@ class InducedSetAttentionBlock(keras.Layer):
             kernel_initializer=kernel_initializer,
             use_bias=use_bias,
             layer_norm=layer_norm,
+            flash_attention=flash_attention,
         )
         self.mab0 = MultiHeadAttentionBlock(**mab_kwargs)
         self.mab1 = MultiHeadAttentionBlock(**mab_kwargs)

--- a/bayesflow/networks/transformers/mab.py
+++ b/bayesflow/networks/transformers/mab.py
@@ -7,6 +7,8 @@ from bayesflow.utils import layer_kwargs, filter_kwargs
 from bayesflow.utils.decorators import sanitize_input_shape
 from bayesflow.utils.serialization import serializable
 
+from .attention import FlashMultiHeadAttention
+
 
 @serializable("bayesflow.networks")
 class MultiHeadAttentionBlock(keras.Layer):
@@ -36,6 +38,7 @@ class MultiHeadAttentionBlock(keras.Layer):
         kernel_initializer: str = "lecun_normal",
         use_bias: bool = True,
         layer_norm: bool = True,
+        flash_attention: bool | None = None,
         **kwargs,
     ):
         """Creates a multi-head attention block which will typically be used as part of a
@@ -61,6 +64,13 @@ class MultiHeadAttentionBlock(keras.Layer):
             Whether to include bias terms in dense layers, by default True.
         layer_norm : bool, optional
             Whether to apply layer normalization before and after attention, by default True.
+        flash_attention : bool or None, optional (default - None)
+            Whether to use flash attention for the internal attention computation. Since dropout
+            is a no-op outside of training, this only affects calls made with `training=False`
+            (e.g. during inference/sampling); training calls always use the regular dropout-enabled
+            attention path whenever `dropout > 0`. If `None`, flash attention is attempted
+            opportunistically whenever the backend/hardware supports it. If `True`, flash attention
+            is required and unsupported inputs raise an error. If `False`, flash attention is disabled.
         **kwargs : dict
             Additional keyword arguments passed to the Keras Layer base class.
         """
@@ -68,12 +78,13 @@ class MultiHeadAttentionBlock(keras.Layer):
         super().__init__(**layer_kwargs(kwargs))
 
         self.input_projector = layers.Dense(units=embed_dim, name="input_projector")
-        self.attention = layers.MultiHeadAttention(
+        self.attention = FlashMultiHeadAttention(
             key_dim=embed_dim,
             num_heads=num_heads,
             dropout=dropout,
             use_bias=use_bias,
             output_shape=embed_dim,
+            flash_attention=flash_attention,
             name="attention",
         )
         self.ln_pre = layers.LayerNormalization(name="layer_norm_pre") if layer_norm else None

--- a/bayesflow/networks/transformers/pma.py
+++ b/bayesflow/networks/transformers/pma.py
@@ -36,6 +36,7 @@ class PoolingByMultiHeadAttention(keras.Layer):
         kernel_initializer: str = "lecun_normal",
         use_bias: bool = True,
         layer_norm: bool = True,
+        flash_attention: bool | None = None,
         **kwargs,
     ):
         """
@@ -66,6 +67,9 @@ class PoolingByMultiHeadAttention(keras.Layer):
             Whether to include bias terms in dense layers.
         layer_norm : bool, optional (default=True)
             Whether to apply layer normalization before and after attention.
+        flash_attention : bool or None, optional (default - None)
+            Whether to use flash attention for the internal attention computation. See
+            `MultiHeadAttentionBlock` for details.
         **kwargs
             Additional keyword arguments passed to the Keras Layer base class.
         """
@@ -82,6 +86,7 @@ class PoolingByMultiHeadAttention(keras.Layer):
             kernel_initializer=kernel_initializer,
             use_bias=use_bias,
             layer_norm=layer_norm,
+            flash_attention=flash_attention,
         )
 
         self.seed_vector = self.add_weight(

--- a/bayesflow/networks/transformers/set_transformer.py
+++ b/bayesflow/networks/transformers/set_transformer.py
@@ -39,6 +39,7 @@ class SetTransformer(SummaryNetwork):
         layer_norm: bool = True,
         num_inducing_points: int = None,
         seed_dim: int = None,
+        flash_attention: bool | None = None,
         **kwargs,
     ):
         """
@@ -75,6 +76,9 @@ class SetTransformer(SummaryNetwork):
             Number of inducing points used, if applicable. If set to None, this option is disabled.
         seed_dim : int or None, optional (default - None)
             Dimensionality of the seed embeddings. If None, it defaults to `summary_dim`.
+        flash_attention : bool or None, optional (default - None)
+            Whether to use flash attention for the internal attention computation. See
+            `MultiHeadAttentionBlock` for details.
         **kwargs : dict
             Additional keyword arguments passed to the base layer.
         """
@@ -94,6 +98,7 @@ class SetTransformer(SummaryNetwork):
             kernel_initializer=kernel_initializer,
             use_bias=use_bias,
             layer_norm=layer_norm,
+            flash_attention=flash_attention,
         )
 
         for i in range(num_attention_layers):

--- a/bayesflow/networks/transformers/time_series_transformer.py
+++ b/bayesflow/networks/transformers/time_series_transformer.py
@@ -27,6 +27,7 @@ class TimeSeriesTransformer(SummaryNetwork):
         time_embedding: str = "time2vec",
         time_embed_dim: int = 8,
         time_axis: int = None,
+        flash_attention: bool | None = None,
         **kwargs,
     ):
         """(SN) Creates a regular transformer coupled with Time2Vec embeddings of time used to flexibly compress time
@@ -63,6 +64,9 @@ class TimeSeriesTransformer(SummaryNetwork):
             The time axis (e.g., -1 for last axis) from which to grab the time vector that goes into the embedding.
             If an embedding is provided and time_axis is None, a uniform time interval between [0, sequence_len]
             will be assumed.
+        flash_attention : bool or None, optional (default - None)
+            Whether to use flash attention for the internal attention computation. See
+            `MultiHeadAttentionBlock` for details.
         **kwargs : dict
             Additional keyword arguments passed to the base layer.
         """
@@ -91,6 +95,7 @@ class TimeSeriesTransformer(SummaryNetwork):
                 kernel_initializer=kernel_initializer,
                 use_bias=use_bias,
                 layer_norm=layer_norm,
+                flash_attention=flash_attention,
                 num_heads=num_heads[i],
                 embed_dim=embed_dims[i],
                 mlp_depth=mlp_depths[i],

--- a/tests/test_networks/test_transformers/test_attention.py
+++ b/tests/test_networks/test_transformers/test_attention.py
@@ -1,0 +1,228 @@
+import keras
+import numpy as np
+import pytest
+
+from bayesflow.networks import SetTransformer
+from bayesflow.networks.transformers.attention import FlashMultiHeadAttention
+from bayesflow.networks.transformers.isab import InducedSetAttentionBlock
+from bayesflow.networks.transformers.mab import MultiHeadAttentionBlock
+from bayesflow.networks.transformers.pma import PoolingByMultiHeadAttention
+from bayesflow.utils.serialization import deserialize, serialize
+
+
+@pytest.fixture()
+def x():
+    return keras.random.normal((2, 6, 3), seed=0)
+
+
+def test_relied_upon_keras_internals_are_present():
+    # Fail clearly if a Keras update removes private attributes used by
+    # `FlashMultiHeadAttention`; see the compatibility note on that class.
+    attn = FlashMultiHeadAttention(key_dim=8, num_heads=2, dropout=0.1)
+    attn.build((2, 6, 3), (2, 6, 3))
+
+    assert isinstance(attn._dropout, float)
+    assert attn._dropout == 0.1
+    assert isinstance(attn._attention_axes, tuple) and len(attn._attention_axes) > 0
+    assert isinstance(attn._inverse_sqrt_key_dim, float)
+    assert callable(getattr(keras.layers.MultiHeadAttention, "_compute_attention", None))
+
+
+def spy_on_dot_product_attention(monkeypatch):
+    """Track calls to the fused dot-product attention operation used by `attention.py`."""
+    import bayesflow.networks.transformers.attention as attention_module
+
+    calls = {"n": 0, "kwargs": None}
+    original = attention_module.ops.dot_product_attention
+
+    def spy(*args, **kwargs):
+        calls["n"] += 1
+        calls["kwargs"] = kwargs
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(attention_module.ops, "dot_product_attention", spy)
+    return calls
+
+
+class TestFastPathGating:
+    def test_training_with_dropout_never_uses_fast_path(self, monkeypatch, x):
+        block = MultiHeadAttentionBlock(embed_dim=8, num_heads=2, dropout=0.3, layer_norm=False)
+        block(x, x, training=False)  # build
+        calls = spy_on_dot_product_attention(monkeypatch)
+
+        block(x, x, training=True)
+        assert calls["n"] == 0
+
+    def test_inference_with_nonzero_configured_dropout_uses_fast_path(self, monkeypatch, x):
+        block = MultiHeadAttentionBlock(embed_dim=8, num_heads=2, dropout=0.3, layer_norm=False)
+        block(x, x, training=False)  # build
+        calls = spy_on_dot_product_attention(monkeypatch)
+
+        block(x, x, training=False)
+        assert calls["n"] == 1
+
+    def test_return_attention_scores_never_uses_fast_path(self, monkeypatch, x):
+        attn = FlashMultiHeadAttention(key_dim=8, num_heads=2, dropout=0.0)
+        attn(query=x, key=x, value=x, training=False)  # build
+        calls = spy_on_dot_product_attention(monkeypatch)
+
+        output, scores = attn(query=x, key=x, value=x, training=False, return_attention_scores=True)
+        assert calls["n"] == 0
+        assert scores is not None
+        assert keras.ops.shape(output)[:-1] == keras.ops.shape(x)[:-1]
+
+    def test_flash_attention_false_is_forwarded_on_fast_path(self, monkeypatch, x):
+        attn = FlashMultiHeadAttention(key_dim=8, num_heads=2, dropout=0.0, flash_attention=False)
+        attn(query=x, key=x, value=x, training=False)  # build
+        calls = spy_on_dot_product_attention(monkeypatch)
+
+        attn(query=x, key=x, value=x, training=False)
+        assert calls["n"] == 1
+        assert calls["kwargs"]["flash_attention"] is False
+
+    def test_default_flash_attention_respects_global_disabling(self, monkeypatch, x):
+        # Regression test: `flash_attention=None` (the default) must defer to
+        # `keras.config.disable_flash_attention()` rather than always attempting flash attention
+        # opportunistically, since `ops.dot_product_attention` never consults that global setting
+        # on its own -- only `keras.layers.MultiHeadAttention.__init__` does, which this class
+        # bypasses.
+        attn = FlashMultiHeadAttention(key_dim=8, num_heads=2, dropout=0.0)  # flash_attention=None
+        attn(query=x, key=x, value=x, training=False)  # build
+        calls = spy_on_dot_product_attention(monkeypatch)
+
+        was_disabled = keras.config.is_flash_attention_enabled() is False
+        keras.config.disable_flash_attention()
+        try:
+            attn(query=x, key=x, value=x, training=False)
+        finally:
+            if not was_disabled:
+                keras.config.enable_flash_attention()
+
+        assert calls["n"] == 1
+        assert calls["kwargs"]["flash_attention"] is False
+
+    def test_construction_safe_under_global_flash_attention_enabled(self, x):
+        # Global FlashAttention must not make construction fail when training dropout is nonzero.
+        was_disabled = keras.config.is_flash_attention_enabled() is False
+        keras.config.enable_flash_attention()
+        try:
+            block = MultiHeadAttentionBlock(embed_dim=8, num_heads=2, dropout=0.05, layer_norm=False)
+            block(x, x, training=True)
+            block(x, x, training=False)
+        finally:
+            # Restore the global setting to avoid affecting later tests.
+            if was_disabled:
+                keras.config.disable_flash_attention()
+            else:
+                keras.config.enable_flash_attention()
+
+
+def test_fast_path_matches_manual_path_at_dropout_zero(x):
+    attn = FlashMultiHeadAttention(key_dim=8, num_heads=2, dropout=0.0)
+    fast_output = attn(query=x, key=x, value=x, training=False)  # build + fast path
+
+    query = attn._query_dense(x)
+    key = attn._key_dense(x)
+    value = attn._value_dense(x)
+    # Requesting scores forces Keras's explicit softmax/einsum reference path. Without it, both
+    # sides of this comparison would use fused dot-product attention.
+    manual_output, _ = keras.layers.MultiHeadAttention._compute_attention(attn, query, key, value, None, False, True)
+    manual_output = attn._output_dense(manual_output)
+
+    np.testing.assert_allclose(
+        keras.ops.convert_to_numpy(fast_output), keras.ops.convert_to_numpy(manual_output), atol=1e-5
+    )
+
+
+def test_attention_mask_matches_manual_path(x):
+    batch, seq = keras.ops.shape(x)[0], keras.ops.shape(x)[1]
+    mask_np = np.ones((batch, seq, seq), dtype=bool)
+    mask_np[:, :, -1] = False  # mask out attending to the last key position
+    mask = keras.ops.convert_to_tensor(mask_np)
+
+    attn = FlashMultiHeadAttention(key_dim=8, num_heads=2, dropout=0.0)
+    fast_output = attn(query=x, key=x, value=x, training=False, attention_mask=mask)
+    assert np.all(np.isfinite(keras.ops.convert_to_numpy(fast_output)))
+
+    query = attn._query_dense(x)
+    key = attn._key_dense(x)
+    value = attn._value_dense(x)
+    manual_output, _ = keras.layers.MultiHeadAttention._compute_attention(attn, query, key, value, mask, False, True)
+    manual_output = attn._output_dense(manual_output)
+
+    np.testing.assert_allclose(
+        keras.ops.convert_to_numpy(fast_output), keras.ops.convert_to_numpy(manual_output), atol=1e-5
+    )
+
+
+@pytest.mark.numpy
+@pytest.mark.tensorflow
+def test_flash_attention_true_raises_on_unsupported_backend(x):
+    # NumPy and TensorFlow reject forced FlashAttention. JAX and PyTorch eligibility depends on
+    # hardware, so their behavior cannot be asserted in this backend-independent test suite.
+    attn = FlashMultiHeadAttention(key_dim=8, num_heads=2, dropout=0.0, flash_attention=True)
+    with pytest.raises(ValueError, match="(?i)flash attention"):
+        attn(query=x, key=x, value=x, training=False)
+
+
+class TestFlashAttentionPropagation:
+    def test_isab_propagates_to_both_mab_blocks(self):
+        isab = InducedSetAttentionBlock(num_inducing_points=4, embed_dim=8, num_heads=2, flash_attention=False)
+        assert isab.mab0.attention._fast_path_flash_attention is False
+        assert isab.mab1.attention._fast_path_flash_attention is False
+
+    def test_pma_propagates_to_its_mab(self):
+        pma = PoolingByMultiHeadAttention(embed_dim=8, num_heads=2, flash_attention=False)
+        assert pma.mab.attention._fast_path_flash_attention is False
+
+    def test_set_transformer_propagates_flash_attention_setting(self, x):
+        st = SetTransformer(
+            summary_dim=4, embed_dims=(8, 8), num_heads=(2, 2), num_inducing_points=3, flash_attention=False
+        )
+        st(x, training=False)  # build
+
+        for block in st.attention_blocks.layers:
+            assert block.mab0.attention._fast_path_flash_attention is False
+            assert block.mab1.attention._fast_path_flash_attention is False
+        assert st.pooling_by_attention.mab.attention._fast_path_flash_attention is False
+
+
+class TestSetTransformerISAB:
+    @pytest.mark.parametrize("training", [True, False])
+    def test_builds_and_runs(self, x, training):
+        st = SetTransformer(summary_dim=4, embed_dims=(8, 8), num_heads=(2, 2), num_inducing_points=3)
+        output = st(x, training=training)
+        assert keras.ops.shape(output) == (keras.ops.shape(x)[0], 4)
+
+
+class TestSerialization:
+    def test_flash_multihead_attention_round_trip(self, x):
+        attn = FlashMultiHeadAttention(key_dim=8, num_heads=2, dropout=0.2, flash_attention=False)
+        attn(query=x, key=x, value=x, training=False)  # build
+
+        config = serialize(attn)
+        reloaded = deserialize(config)
+
+        assert reloaded._dropout == 0.2
+        assert reloaded._fast_path_flash_attention is False
+        assert keras.tree.lists_to_tuples(config) == keras.tree.lists_to_tuples(serialize(reloaded))
+
+    def test_set_transformer_isab_flash_attention_round_trip(self, x):
+        st = SetTransformer(
+            summary_dim=4,
+            embed_dims=(8,),
+            num_heads=(2,),
+            mlp_depths=(2,),
+            mlp_widths=(32,),
+            num_inducing_points=3,
+            flash_attention=False,
+        )
+        st(x, training=False)
+
+        config = serialize(st)
+        reloaded = deserialize(config)
+        reloaded(x, training=False)
+
+        for block in reloaded.attention_blocks.layers:
+            assert block.mab0.attention._fast_path_flash_attention is False
+            assert block.mab1.attention._fast_path_flash_attention is False


### PR DESCRIPTION
## Summary

This PR adds configurable FlashAttention support to BayesFlow's transformer attention blocks and decouples the fused inference path from training-time attention dropout.

Previously, Keras only selected fused dot-product attention when the configured dropout rate was zero. Since BayesFlow uses nonzero dropout by default, the fused path remained unavailable during inference even though dropout is inactive then.

The new implementation preserves dropout-enabled attention during training while allowing fused dot-product attention—and FlashAttention when supported—during inference.

## Changes

- Added `FlashMultiHeadAttention`, extending Keras `MultiHeadAttention`.
- Preserved standard attention during training when `dropout > 0`.
- Enabled fused dot-product attention during inference regardless of the configured training dropout.
- Added `flash_attention: bool | None` to:
  - `MultiHeadAttentionBlock`
  - `InducedSetAttentionBlock`
  - `PoolingByMultiHeadAttention`
  - `SetTransformer`
  - `TimeSeriesTransformer`
  - `FusionTransformer`
- Propagated the setting through both ISAB cross-attention operations and the final PMA block.
- Respected the global Keras FlashAttention configuration when `flash_attention=None`.
- Preserved the standard attention path when attention scores are requested.
- Added compatibility handling for Keras 3.12 and newer `_compute_attention` signatures.
- Added serialization support for the custom attention layer and SetTransformer configurations.
- Added focused tests for dispatch, numerical correctness, masks, inducing points, and serialization.

## Configuration

The new argument supports three modes:

- `flash_attention=None`: defer to the global Keras configuration and backend capabilities.
- `flash_attention=True`: require FlashAttention for eligible fused calls and raise if unsupported.
- `flash_attention=False`: disable FlashAttention while retaining fused dot-product attention where available.

Example:

```python
# Default: backend and hardware determine whether FlashAttention is used.
summary_network = SetTransformer(
    summary_dim=16,
    num_inducing_points=32,
)

# Require FlashAttention and raise if the backend or inputs do not support it.
summary_network = SetTransformer(
    summary_dim=16,
    num_inducing_points=32,
    flash_attention=True,
)
```

## Test plan

- Added `tests/test_networks/test_transformers/test_attention.py` with 17 tests covering:
  - Fast-path and dropout gating, verified by spying on `ops.dot_product_attention` rather than checking only output shapes.
  - Numerical parity with Keras's explicit reference implementation.
  - Attention masking.
  - `return_attention_scores`.
  - Propagation of `flash_attention` through ISAB, PMA, and SetTransformer.
  - Serialization round trips.
  - The unsupported-backend error path.
  - The global-disable regression.
  - A guard test that fails clearly if a future Keras release removes the private attributes used by the implementation.
- Verified against `keras==3.12.0`, the declared minimum, and `keras==3.15.0`, on both JAX and TensorFlow backends.
- Confirmed the Keras 3.12 incompatibility by reproducing it before applying the compatibility fix.

## GPU verification status
A follow-up CUDA test is still needed to confirm that a real FlashAttention kernel is selected at runtime for ISAB's cross-attention shapes rather than falling back to regular attention.