### PR TITLE
Support the documented aggregation=None in calibration_error

### DIFF
--- a/bayesflow/diagnostics/metrics/calibration_error.py
+++ b/bayesflow/diagnostics/metrics/calibration_error.py
@@ -13,7 +13,7 @@ def calibration_error(
     variable_names: Sequence[str] = None,
     test_quantities: dict[str, Callable] = None,
     resolution: int = 20,
-    aggregation: Callable = np.median,
+    aggregation: Callable | None = np.median,
     min_quantile: float = 0.005,
     max_quantile: float = 0.995,
 ) -> dict[str, Any]:
@@ -116,10 +116,11 @@ def calibration_error(
     alpha_pred = np.mean(inlier_id, axis=1)
 
     # Calculate absolute error between predicted inliers and alpha
-    absolute_errors = np.abs(alpha_pred - alphas[:, None])
+    error = np.abs(alpha_pred - alphas[:, None])
 
     # Aggregate errors across alpha
-    error = aggregation(absolute_errors, axis=0)
+    if aggregation is not None:
+        error = aggregation(error, axis=0)
 
     variable_names = samples["estimates"].variable_names
     return {"values": error, "metric_name": "Calibration Error", "variable_names": variable_names}

--- a/tests/test_diagnostics/test_diagnostics_metrics.py
+++ b/tests/test_diagnostics/test_diagnostics_metrics.py
@@ -36,6 +36,10 @@ def test_metric_calibration_error(random_estimates, random_targets, var_names):
     assert out["values"].shape == (random_estimates["sigma"].shape[-1],)
     assert out["variable_names"] == ["sigma"]
 
+    # test without aggregation
+    out = bf.diagnostics.metrics.calibration_error(random_estimates, random_targets, resolution=20, aggregation=None)
+    assert out["values"].shape == (20, num_variables(random_estimates))
+
     # test quantities
     test_quantities = {
         r"$\beta_1 + \beta_2$": lambda data: np.sum(data["beta"], axis=-1),


### PR DESCRIPTION
`calibration_error` documents that `aggregation=None` returns the per-alpha errors, but passing it raises `TypeError: 'NoneType' object is not callable`.

The docstring (`bayesflow/diagnostics/metrics/calibration_error.py:55-57`):

```
aggregation   : Callable or None, optional, default: np.median
    The function used to aggregate the marginal calibration errors.
    If ``None`` provided, the per-alpha calibration errors will be returned.
```

and the code (`bayesflow/diagnostics/metrics/calibration_error.py:122`):

```python
error = aggregation(absolute_errors, axis=0)
```

`posterior_contraction` (`posterior_contraction.py:94-95`) and `posterior_z_score` (`posterior_z_score.py:109-110`) both declare `Callable | None` and guard with `if aggregation is not None:`. `calibration_error` declares `Callable` and calls unconditionally, so the documented `None` never worked. This PR applies the same guard.

The mismatch is also visible through `BasicWorkflow.compute_default_diagnostics`, which forwards `calibration_error_kwargs` straight to the metric (`bayesflow/workflows/basic_workflow.py:1086-1092`): `posterior_contraction_kwargs={"aggregation": None}` works, `calibration_error_kwargs={"aggregation": None}` raises.

## Reproduction

```python
import numpy as np
import bayesflow as bf

rng = np.random.default_rng(0)
estimates = {"beta": rng.standard_normal((32, 100, 2)), "sigma": rng.standard_normal((32, 100, 1))}
targets = {"beta": rng.standard_normal((32, 2)), "sigma": rng.standard_normal((32, 1))}

pc = bf.diagnostics.metrics.posterior_contraction(estimates, targets, aggregation=None)
print("posterior_contraction(aggregation=None) ->", pc["values"].shape)

ce = bf.diagnostics.metrics.calibration_error(estimates, targets, aggregation=None)
print("calibration_error(aggregation=None)     ->", ce["values"].shape)
```

Before, on `dev` @ db644d1:

```
posterior_contraction(aggregation=None) -> (32, 3)
Traceback (most recent call last):
  File "repro.py", line 11, in <module>
    ce = bf.diagnostics.metrics.calibration_error(estimates, targets, aggregation=None)
  File "bayesflow/diagnostics/metrics/calibration_error.py", line 122, in calibration_error
    error = aggregation(absolute_errors, axis=0)
TypeError: 'NoneType' object is not callable
```

After:

```
posterior_contraction(aggregation=None) -> (32, 3)
calibration_error(aggregation=None)     -> (20, 3)
```

`(20, 3)` is `(resolution, num_variables)`, i.e. one absolute error per alpha per variable, which is what the docstring promises. The un-aggregated shape is `(resolution, ...)` rather than the siblings' `(num_datasets, ...)` because `calibration_error` aggregates over alphas, not over datasets.

Through the workflow (`compute_default_diagnostics(..., as_data_frame=False)`), before:

```
posterior_contraction_kwargs     -> OK   {'NRMSE': (2,), 'Log Gamma': (2,), 'Calibration Error': (2,), 'Posterior Contraction': (8, 2)}
calibration_error_kwargs         -> TypeError: 'NoneType' object is not callable
```

after:

```
posterior_contraction_kwargs     -> OK   {'NRMSE': (2,), 'Log Gamma': (2,), 'Calibration Error': (2,), 'Posterior Contraction': (8, 2)}
calibration_error_kwargs         -> OK   {'NRMSE': (2,), 'Log Gamma': (2,), 'Calibration Error': (20, 2), 'Posterior Contraction': (2,)}
```

## Tests

`test_metric_calibration_error` gets the same `aggregation=None` assertion that `test_posterior_contraction` and `test_posterior_z_score` already have. It fails on unpatched `dev` with the `TypeError` above and passes with the fix.

`pytest tests/test_diagnostics tests/test_utils tests/test_datasets` — 351 passed, 36 skipped (torch backend, Python 3.12). `pytest tests/test_workflows` — 69 passed, 1 failed; the failure is `test_diffusion_compositional_guidance`, which also fails on unmodified `dev` and is unrelated.

## Note

`root_mean_squared_error` (`root_mean_squared_error.py:146`) and `correlation` (`correlation.py:98`) have the same unguarded `aggregation(...)` call, but their docstrings do not advertise `None`, so those are an API-consistency gap rather than a contradiction. I left them out to keep this PR to the actual bug — `root_mean_squared_error` in particular has a second call site at `:138` for the `normalize="prior"` bootstrap normalizer, which has to keep collapsing regardless, and picking what it should do when `aggregation is None` is a design decision rather than a fix. Happy to extend this PR or open a follow-up if you would like `aggregation=None` supported uniformly.
