### PR TITLE
Fix NumPy inverse_softplus for non-unit beta

### DIFF
--- a/bayesflow/utils/numpy_utils.py
+++ b/bayesflow/utils/numpy_utils.py
@@ -18,8 +18,8 @@ def inverse_shifted_softplus(
 def inverse_softplus(x: np.ndarray, beta: float = 1.0, threshold: float = 20.0) -> np.ndarray:
     """Numerically stabilized inverse softplus function."""
     with np.errstate(over="ignore"):
-        expm1_x = np.expm1(x)
-    return np.where(beta * x > threshold, x, np.log(beta * expm1_x) / beta)
+        expm1_beta_x = np.expm1(beta * x)
+    return np.where(beta * x > threshold, x, np.log(expm1_beta_x) / beta)
 
 
 def one_hot(indices: np.ndarray, num_classes: int, dtype: str = "float32") -> np.ndarray:

--- a/tests/test_utils/test_numpy_utils.py
+++ b/tests/test_utils/test_numpy_utils.py
@@ -1,0 +1,59 @@
+import keras
+import numpy as np
+import pytest
+
+from bayesflow.utils import keras_utils, numpy_utils
+
+
+@pytest.mark.parametrize("beta", [0.5, 1.0, 2.0])
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+def test_inverse_softplus_round_trip(beta, dtype):
+    x = np.array([-20.0, -2.0, -0.5, 0.0, 0.5, 2.0, 19.0, 20.0, 21.0, 1000.0], dtype=dtype) / beta
+    y = np.array([1e-8, 0.1, 1.0, 10.0, 30.0, 1000.0], dtype=dtype) / beta
+    tolerance = 2e-6 if dtype == "float32" else 1e-8
+
+    # The large values overflow the unused exponential branch, which must stay silent.
+    with np.errstate(over="raise", invalid="raise", divide="raise"):
+        recovered_x = numpy_utils.inverse_softplus(numpy_utils.softplus(x, beta=beta), beta=beta)
+        recovered_y = numpy_utils.softplus(numpy_utils.inverse_softplus(y, beta=beta), beta=beta)
+
+    np.testing.assert_allclose(recovered_x, x, rtol=tolerance, atol=tolerance)
+    np.testing.assert_allclose(recovered_y, y, rtol=tolerance, atol=0)
+
+
+@pytest.mark.parametrize("beta", [0.5, 1.0, 2.0])
+@pytest.mark.parametrize("shift", [np.log(np.e - 1), -1.5])
+def test_inverse_shifted_softplus_round_trip(beta, shift):
+    x = np.array([-2.0, -0.5, 0.0, 0.5, 2.0])
+    y = numpy_utils.shifted_softplus(x, beta=beta, shift=shift)
+    recovered = numpy_utils.inverse_shifted_softplus(y, beta=beta, shift=shift)
+
+    np.testing.assert_allclose(recovered, x, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize("beta", [0.5, 1.0, 2.0])
+@pytest.mark.parametrize("threshold", [2.0, 20.0])
+def test_inverse_softplus_matches_keras(beta, threshold):
+    x = np.array([1e-6, 0.5, threshold - 0.25, threshold, threshold + 0.25, 1000.0], dtype="float32") / beta
+
+    actual = numpy_utils.inverse_softplus(x, beta=beta, threshold=threshold)
+    expected = keras.ops.convert_to_numpy(
+        keras_utils.inverse_softplus(keras.ops.convert_to_tensor(x), beta=beta, threshold=threshold)
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=2e-6, atol=2e-6)
+
+
+@pytest.mark.parametrize("beta", [0.5, 1.0, 2.0])
+def test_inverse_softplus_threshold(beta):
+    # A low threshold makes the strict boundary observable instead of rounding to x.
+    threshold = 2.0
+    x = np.array([threshold - 0.25, threshold, threshold + 0.25, 1000.0]) / beta
+
+    with np.errstate(over="raise", invalid="raise", divide="raise"):
+        actual = numpy_utils.inverse_softplus(x, beta=beta, threshold=threshold)
+
+    # log(exp(z) - 1) = z + log(1 - exp(-z)), an independent stable reference.
+    expected_below = x[:2] + np.log1p(-np.exp(-beta * x[:2])) / beta
+    np.testing.assert_allclose(actual[:2], expected_below, rtol=1e-12, atol=1e-12)
+    np.testing.assert_array_equal(actual[2:], x[2:])


### PR DESCRIPTION
`numpy_utils.inverse_softplus` does not invert `softplus` when beta differs from 1. This also affects `inverse_shifted_softplus`; in-tree adapter calls using default beta=1 are unaffected.

### Reproduction

With a configured Keras backend, e.g. `KERAS_BACKEND=torch`:

```python
import numpy as np
from bayesflow.utils import numpy_utils

x = np.array([0.0])
for beta in (0.5, 1.0, 2.0):
    y = numpy_utils.softplus(x, beta=beta)
    print(beta, numpy_utils.inverse_softplus(y, beta=beta))
```

Expected: zero to floating-point accuracy for each beta. Before this fix the results are approximately 0.81093, 0, and -0.09411. The Keras inverse already returns the correct result. No exception is raised.

### Change

Move beta inside `expm1`: the inverse of `log1p(exp(beta*x))/beta` is `log(expm1(beta*y))/beta`. Preserve the existing strict threshold comparison, linear branch and overflow suppression from #275, which addressed #270.

Add regressions for both round-trip directions, shifted round trips, Keras parity, threshold boundaries and large inputs. Fourteen non-unit-beta cases fail before the fix; all 21 focused cases pass afterward.

### Validation

- PyTorch utility/adapter suites: 187 passed, 4 skipped.
- Focused JAX and TensorFlow tests: 21 passed on each backend.
- Repository-wide Ruff lint/format and changed-file pre-commit checks pass.
- Python 3.12.12, NumPy 2.5.2, Keras 3.15.1, macOS arm64. Full CI OS/backend matrix and documentation build not run.

No separate issue is linked; this description includes the reproduction, expected behavior and proposed scope using the no-issue route in contribution-guide step 5. No API or dependency changes.

### CI follow-up

The macOS Torch job currently fails in the existing `test_jacobian_numerically` ActNorm case at `torch.logdet` on an MPS identity matrix, with a Metal `unsupported deferred-static-alloca-size` compiler error. The four corresponding ActNorm/affine Jacobian cases pass locally on this branch. This does not establish that the CI environment failure is resolved; no tests were disabled or retried to hide it. The changed NumPy utility does not appear in the failure traceback.
