### PR TITLE
Fix 1D coupling regression and add test

### DIFF
--- a/bayesflow/networks/inference/coupling/layers/dual_coupling.py
+++ b/bayesflow/networks/inference/coupling/layers/dual_coupling.py
@@ -65,6 +65,9 @@ class DualCoupling(InvertibleLayer):
 
         if self.pivot:
             self.coupling2.build(x2_shape, x1_shape, conditions_shape)
+        else:
+            self._tracker.untrack(self.coupling2)
+            self.coupling2 = None
 
     def call(
         self, xz: Tensor, conditions: Tensor = None, inverse: bool = False, training: bool = False, **kwargs

--- a/tests/test_workflows/test_basic_workflow.py
+++ b/tests/test_workflows/test_basic_workflow.py
@@ -88,6 +88,22 @@ def test_unconditional_sampling(inference_network):
     assert samples["parameters"].shape == (3, 2)
 
 
+def test_one_dimensional_coupling_flow():
+    data = {
+        "parameters": np.random.normal(size=(4, 1)),
+        "observables": np.random.normal(size=(4, 2)),
+    }
+    workflow = bf.BasicWorkflow(
+        inference_network=bf.networks.CouplingFlow(depth=1, subnet_kwargs=dict(widths=(8,))),
+        inference_variables="parameters",
+        inference_conditions="observables",
+    )
+
+    history = workflow.fit_offline(data, epochs=1, batch_size=2, verbose=0)
+
+    assert len(history.history["loss"]) == 1
+
+
 def test_ancestral_sampling():
     """
     Hierarchical scenario:


### PR DESCRIPTION
Autobuilding a coupling flow with a 1d target is broken under Keras 3.15 due to an upstream change in tracking. The fix is to untrack the unused `coupling2` branch if the `pivot` variable is 0 (=> 1D target). Also added a new test. Addresses #767.