### PR TITLE
Fix node expansion in GraphicalSimulator

### DIFF
--- a/bayesflow/experimental/graphical_approximator/example_approximators/three_level_approximator.py
+++ b/bayesflow/experimental/graphical_approximator/example_approximators/three_level_approximator.py
@@ -16,6 +16,7 @@ def three_level_approximator():
         DeepSet(summary_dim=30),
         DeepSet(summary_dim=40),
         DeepSet(summary_dim=50),
+        DeepSet(summary_dim=60),
     ]
     inference_networks = [CouplingFlow(), CouplingFlow(), CouplingFlow()]
 

--- a/bayesflow/experimental/graphs/simulation_graph.py
+++ b/bayesflow/experimental/graphs/simulation_graph.py
@@ -22,7 +22,7 @@ SimulationNode: TypeAlias = str
 ExpandedNode: TypeAlias = str
 
 
-@serializable("bayesflow.experimental")  # type: ignore[missing-argument]
+@serializable("bayesflow.experimental")
 class SimulationGraph(nx.DiGraph):
     """
     Directed acyclic graph defining a model.
@@ -68,11 +68,18 @@ class SimulationGraph(nx.DiGraph):
         if merge_roots:
             graph = merge_root_nodes(graph)
 
-        for node in nx.lexicographical_topological_sort(graph):
-            interior_node = graph.in_degree(node) != 0 and graph.out_degree(node) != 0
+        for node in list(nx.lexicographical_topological_sort(graph)):
+            node_copies = []
+            for candidate in graph.nodes:
+                previous_names = graph.nodes[candidate].get("previous_names", [])
+                if candidate == node or node in previous_names:
+                    node_copies.append(candidate)
 
-            if interior_node and node in graph.nodes:
-                graph = split_node(graph, node)
+            for node_copy in node_copies:
+                interior_node = graph.in_degree(node_copy) != 0 and graph.out_degree(node_copy) != 0
+
+                if interior_node:
+                    graph = split_node(graph, node_copy)
 
         for node in nx.lexicographical_topological_sort(graph):
             for key in ["split_by", "previous_names", "merged_from"]:

--- a/tests/test_experimental/test_graphical_approximator/test_inference_conditions.py
+++ b/tests/test_experimental/test_graphical_approximator/test_inference_conditions.py
@@ -48,15 +48,15 @@ def test_inference_conditions_three_level(three_level_simulator, three_level_app
     expected_shape = (2, 33)  # 30 summary dimensions + 3 node reps
     assert keras.ops.shape(conditions[0]) == expected_shape
 
+    expected_shape = (2, data.meta["N_classrooms"], 56)  # 50 summary dimensions + 3 variables + 3 node reps
+    assert keras.ops.shape(conditions[1]) == expected_shape
+
     expected_shape = (
         2,
         data.meta["N_classrooms"],
         data.meta["N_students"],
-        46,
-    )  # 40 summary dimensions + 3 variables + 3 node reps
-    assert keras.ops.shape(conditions[1]) == expected_shape
-
-    expected_shape = (2, data.meta["N_classrooms"], 56)  # 50 summary dimensions + 3 variables + 3 node reps
+        68,
+    )  # 60 summary dimensions + 5 variables + 3 node reps
     assert keras.ops.shape(conditions[2]) == expected_shape
 
 
@@ -113,13 +113,13 @@ def test_inference_condition_shapes_by_network_three_level(three_level_simulator
     data_shapes = three_level_approximator._data_shapes(data)
     expected_shapes = {
         0: (2, 33),  # 30 summary dimensions + 3 node reps
-        1: (
+        1: (2, data.meta["N_classrooms"], 56),  # 50 summary dimensions + 3 variables + 3 node reps
+        2: (
             2,
             data.meta["N_classrooms"],
             data.meta["N_students"],
-            46,
-        ),  # 40 summary dimensions + 3 variables + 3 node reps
-        2: (2, data.meta["N_classrooms"], 56),  # 50 summary dimensions + 3 variables + 3 node reps
+            68,
+        ),  # 60 summary dimensions + 5 variables + 3 node reps
     }
 
     assert inference_condition_shapes_by_network(three_level_approximator, data_shapes) == expected_shapes

--- a/tests/test_experimental/test_graphical_approximator/test_inference_variables.py
+++ b/tests/test_experimental/test_graphical_approximator/test_inference_variables.py
@@ -108,16 +108,16 @@ def test_inference_variables_by_network_three_level(three_level_simulator, three
     expected_output = concatenate([school_mu, school_sigma, shared_sigma])
     assert keras.ops.all(variables[0] == expected_output)
 
-    student_mu = approximator.standardize_layers["student_mu"](data["student_mu"], stage="validation")
-    student_sigma = approximator.standardize_layers["student_sigma"](data["student_sigma"], stage="validation")
-
-    expected_output = concatenate([student_mu, student_sigma])
-    assert keras.ops.all(variables[1] == expected_output)
-
     classroom_mu = approximator.standardize_layers["classroom_mu"](data["classroom_mu"], stage="validation")
     classroom_sigma = approximator.standardize_layers["classroom_sigma"](data["classroom_sigma"], stage="validation")
 
     expected_output = concatenate([classroom_mu, classroom_sigma])
+    assert keras.ops.all(variables[1] == expected_output)
+
+    student_mu = approximator.standardize_layers["student_mu"](data["student_mu"], stage="validation")
+    student_sigma = approximator.standardize_layers["student_sigma"](data["student_sigma"], stage="validation")
+
+    expected_output = concatenate([student_mu, student_sigma])
     assert keras.ops.all(variables[2] == expected_output)
 
     variable_shapes = inference_variable_shapes_by_network(approximator, data_shapes)
@@ -196,13 +196,13 @@ def test_inference_variable_shapes_by_network_three_level(three_level_approximat
 
     expected_shapes = {
         0: (sp.Symbol("B"), 3),  # 3 variables (school_mu, school_sigma, shared_sigma)
-        1: (
+        1: (sp.Symbol("B"), sp.Symbol("N_classrooms"), 2),  # 2 variables (classroom_mu, classroom_sigma)
+        2: (
             sp.Symbol("B"),
             sp.Symbol("N_classrooms"),
             sp.Symbol("N_students"),
             2,
         ),  # 2 variables (student_mu, student_sigma)
-        2: (sp.Symbol("B"), sp.Symbol("N_classrooms"), 2),  # 2 variables (classroom_mu, classroom_sigma)
     }
     assert inference_variable_shapes_by_network(three_level_approximator) == expected_shapes
 

--- a/tests/test_experimental/test_graphs/test_factorizations.py
+++ b/tests/test_experimental/test_graphs/test_factorizations.py
@@ -68,8 +68,8 @@ def test_node_name_mapping_three_level(three_level_expanded_graph):
     assert node_name_mapping(three_level_expanded_graph) == {
         ("schools", "shared"): ["schools, shared"],
         ("classrooms",): ["classrooms_1", "classrooms_2"],
-        ("students",): ["students_1", "students_2"],
-        ("scores",): ["scores_1", "scores_2"],
+        ("students",): ["students_11", "students_12", "students_21", "students_22"],
+        ("scores",): ["scores_11", "scores_12", "scores_21", "scores_22"],
     }
 
 
@@ -151,8 +151,8 @@ def test_select_factorization_three_level(three_level_expanded_graph):
     #        scores
     selected = select_factorization(enumerate_factorizations(three_level_expanded_graph))
 
-    assert selected.network_composition() == {0: ["schools", "shared"], 1: ["students"], 2: ["classrooms"]}
-    assert len(selected.summary_network_input_shapes()) == 5
+    assert selected.network_composition() == {0: ["schools", "shared"], 1: ["classrooms"], 2: ["students"]}
+    assert len(selected.summary_network_input_shapes()) == 6
 
 
 def test_select_factorization_crossed_design_irt(crossed_design_irt_simulator):

--- a/tests/test_experimental/test_graphs/test_inverted_graph.py
+++ b/tests/test_experimental/test_graphs/test_inverted_graph.py
@@ -18,7 +18,7 @@ def test_network_conditions(single_level_graph, two_level_graph, three_level_gra
     assert three_level_graph.network_conditions() == {
         0: ["scores"],
         1: ["schools", "shared", "scores"],
-        2: ["schools", "shared", "students"],
+        2: ["schools", "classrooms", "shared", "scores"],
     }
 
     assert crossed_design_irt_graph.network_conditions() == {
@@ -35,8 +35,8 @@ def test_network_compositions(single_level_graph, two_level_graph, three_level_g
 
     assert three_level_graph.network_composition() == {
         0: ["schools", "shared"],
-        1: ["students"],
-        2: ["classrooms"],
+        1: ["classrooms"],
+        2: ["students"],
     }
 
     assert crossed_design_irt_graph.network_composition() == {
@@ -86,13 +86,17 @@ def test_original_node_names(single_level_graph, two_level_graph, three_level_gr
         "locals_2": "locals",
     }
     assert three_level_graph.original_node_names() == {
-        "scores_1": "scores",
-        "scores_2": "scores",
+        "scores_11": "scores",
+        "scores_12": "scores",
+        "scores_21": "scores",
+        "scores_22": "scores",
         "schools, shared": ["schools", "shared"],
         "classrooms_1": "classrooms",
         "classrooms_2": "classrooms",
-        "students_1": "students",
-        "students_2": "students",
+        "students_11": "students",
+        "students_12": "students",
+        "students_21": "students",
+        "students_22": "students",
     }
     assert crossed_design_irt_graph.original_node_names() == {
         "observations_11": "observations",
@@ -119,8 +123,8 @@ def test_conditions_by_node(single_level_graph, two_level_graph, three_level_gra
         "scores": [],
         "schools": ["scores"],
         "shared": ["scores"],
-        "students": ["schools", "shared", "scores"],
-        "classrooms": ["schools", "shared", "students"],
+        "classrooms": ["schools", "shared", "scores"],
+        "students": ["schools", "classrooms", "shared", "scores"],
     }
     assert crossed_design_irt_graph.conditions_by_node() == {
         "observations": [],
@@ -140,13 +144,17 @@ def test_detailed_conditions_by_node(single_level_graph, two_level_graph, three_
         "locals_2": ["hypers, shared", "y_2"],
     }
     assert three_level_graph.detailed_conditions_by_node() == {
-        "scores_1": [],
-        "scores_2": [],
-        "schools, shared": ["scores_1", "scores_2"],
-        "students_1": ["scores_1", "schools, shared"],
-        "students_2": ["scores_2", "schools, shared"],
-        "classrooms_1": ["schools, shared", "students_1"],
-        "classrooms_2": ["schools, shared", "students_2"],
+        "scores_11": [],
+        "scores_12": [],
+        "scores_21": [],
+        "scores_22": [],
+        "schools, shared": ["scores_11", "scores_12", "scores_21", "scores_22"],
+        "classrooms_1": ["schools, shared", "scores_11", "scores_12"],
+        "classrooms_2": ["schools, shared", "scores_21", "scores_22"],
+        "students_11": ["classrooms_1", "scores_11", "schools, shared"],
+        "students_12": ["classrooms_1", "scores_12", "schools, shared"],
+        "students_21": ["classrooms_2", "scores_21", "schools, shared"],
+        "students_22": ["classrooms_2", "scores_22", "schools, shared"],
     }
     assert crossed_design_irt_graph.detailed_conditions_by_node() == {
         "observations_11": [],
@@ -195,10 +203,10 @@ def test_non_amortizable_summary_input_shapes(crossed_design_irt_graph):
 def test_is_per_level_summary(three_level_graph):
     # schools is merged with shared in the inverted graph, so no classrooms condition on it directly
     assert three_level_graph.is_per_level_summary("classrooms", "schools") is False
-    # classrooms are inferred after students, so they no longer condition on scores directly
-    assert three_level_graph.is_per_level_summary("classrooms", "scores") is False
-    # students are nested within classrooms, not shared across groups
-    assert three_level_graph.is_per_level_summary("classrooms", "students") is True
+    # classrooms are inferred before students, so each classroom conditions on the scores nested within it
+    assert three_level_graph.is_per_level_summary("classrooms", "scores") is True
+    # classrooms are inferred before students, so they do not condition on students
+    assert three_level_graph.is_per_level_summary("classrooms", "students") is False
 
 
 def test_inverted_graph_serialization(single_level_graph):


### PR DESCRIPTION
The new factorization enumeration exposed a bug in the graph expansion algorithm that previously did not matter: For the three-level example model (schools -> classrooms -> students), the expanded graph only contains a single student within each classroom, that is, classroom_1 -> student_1 and classroom_2 -> student_2.

For the posterior factorization, that means that students are exchangeable even when not conditioning on the classroom parameters. This situation could not arise with the previous inverse Stuhlmüller default, but since we are now enumerating all possible node orderings, each expanded node must always include two copies of each child, otherwise we get an incorrect posterior factorization.

This PR ensures that graph expansion always fully expands all nodes, so that classroom_1 has two children student_11 and student_12 and classroom_2 has two children student_21 and student_22. By doing so, graph inversion can then factorize the posterior correctly, independent of the node ordering.